### PR TITLE
Fix the name of the column in the result

### DIFF
--- a/docs/cookbook/cookbook-code.clj
+++ b/docs/cookbook/cookbook-code.clj
@@ -325,7 +325,7 @@ columns-to-select
       {:n-snow-days (g/count-distinct
                      (g/when (g/like (g/lower :weather) "%snow%") :day))
        :n-days      (g/count-distinct :day)
-       :mean-temp   (g/mean :temp)})
+       :mean-temp   (g/mean :temp-c)})
     (g/order-by :year :month)
     (g/select {:year      :year
                :month     :month
@@ -337,7 +337,7 @@ columns-to-select
 (-> weather-2012
     (g/with-column :weather-description (g/explode (g/split :weather ",")))
     (g/group-by :weather-description)
-    (g/agg {:mean-temp (g/mean :temp)
+    (g/agg {:mean-temp (g/mean :temp-c)
             :n-days    (g/count-distinct :year :month :day)})
     (g/order-by (g/desc :mean-temp))
     (g/select {:weather-description :weather-description


### PR DESCRIPTION
Hi,

While going through the example in the cookbook, I found the errors in the evaluation via REPL.

```
Execution error (AnalysisException) at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt/failAnalysis (package.scala:42).
cannot resolve '`temp`' given input columns: [date-time, day, dew-point-temp-c, latitude-y, longitude-x, month, rel-hum, stn-press-k-pa, temp-c, visibility-km, weather, wind-spd-kmh, year];;
'Aggregate [year#5877, month#5878], [year#5877, month#5878, count(distinct CASE WHEN lower(weather#5886) LIKE %snow% THEN day#5879 END) AS n-snow-days#5962L, count(distinct day#5879) AS n-days#5963L, avg('temp) AS mean-temp#5964]
+- Relation[longitude-x#5874,latitude-y#5875,date-time#5876,year#5877,month#5878,day#5879,temp-c#5880,dew-point-temp-c#5881,rel-hum#5882,wind-spd-kmh#5883,visibility-km#5884,stn-press-k-pa#5885,weather#5886] csv
```
After changing `temp` to `temp-c` then I was able to get the right result at the REPL.

Thanks