### PR TITLE
Managed tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .geni-stdout
 .nrepl-history
 *.cast
+spark-warehouse/
+spark-warehouses/
 
 *.DS_Store*
 .clj-kondo/.cache

--- a/src/clojure/zero_one/geni/catalog.clj
+++ b/src/clojure/zero_one/geni/catalog.clj
@@ -1,0 +1,335 @@
+(ns zero-one.geni.catalog
+  (:require [zero-one.geni.defaults :as defaults])
+  (:import (org.apache.spark.sql.catalog Catalog)
+           (org.apache.spark.sql Dataset SparkSession)
+           (org.apache.spark.storage StorageLevel)
+           (clojure.lang Keyword)))
+
+
+(defn table-identifier
+  [database name] (str database "." name))
+
+
+(defn catalog ^Catalog
+  ([]
+   (catalog @defaults/spark))
+  ([^SparkSession spark]
+   (. spark catalog)))
+
+
+(defn- catalog-dispatch
+  [& args]
+  (mapv class args))
+
+
+(defmulti cache-table catalog-dispatch)
+(defmethod cache-table [String]
+  [^String table-name]
+  (cache-table @defaults/spark table-name))
+(defmethod cache-table [String StorageLevel]
+  [^String table-name ^StorageLevel storage-level]
+  (cache-table @defaults/spark table-name storage-level))
+(defmethod cache-table [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (cache-table (catalog spark) table-name))
+(defmethod cache-table [SparkSession String StorageLevel]
+  [^SparkSession spark ^String table-name ^StorageLevel storage-level]
+  (cache-table (catalog spark) table-name storage-level))
+(defmethod cache-table [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog cacheTable table-name))
+(defmethod cache-table [Catalog String StorageLevel]
+  [^Catalog catalog ^String table-name ^StorageLevel storage-level]
+  (. catalog cacheTable table-name storage-level))
+
+
+(defmulti clear-cache catalog-dispatch)
+(defmethod clear-cache []
+  []
+  (clear-cache @defaults/spark))
+(defmethod clear-cache [SparkSession]
+  [^SparkSession spark]
+  (clear-cache (catalog spark)))
+(defmethod clear-cache [Catalog]
+  [^Catalog catalog]
+  (. catalog clearCache))
+
+
+(defmulti current-database ^String catalog-dispatch)
+(defmethod current-database []
+  []
+  (current-database @defaults/spark))
+(defmethod current-database [SparkSession]
+  [^SparkSession spark]
+  (current-database (catalog spark)))
+(defmethod current-database [Catalog]
+  [^Catalog catalog]
+  (. catalog currentDatabase))
+
+
+(defmulti database-exists? ^Boolean catalog-dispatch)
+(defmethod database-exists? [String]
+  [^String db-name]
+  (database-exists? @defaults/spark db-name))
+(defmethod database-exists? [SparkSession String]
+  [^SparkSession spark ^String db-name]
+  (database-exists? (catalog spark) db-name))
+(defmethod database-exists? [Catalog String]
+  [^Catalog catalog ^String db-name]
+  (. catalog databaseExists db-name))
+
+
+(defmulti drop-temp-view ^Boolean catalog-dispatch)
+(defmethod drop-temp-view [String]
+  [^String view-name]
+  (drop-temp-view @defaults/spark view-name))
+(defmethod drop-temp-view [SparkSession String]
+  [^SparkSession spark ^String view-name]
+  (drop-temp-view (catalog spark) view-name))
+(defmethod drop-temp-view [Catalog String]
+  [^Catalog catalog ^String view-name]
+  (. catalog dropTempView view-name))
+
+
+(defmulti drop-global-temp-view ^Boolean catalog-dispatch)
+(defmethod drop-global-temp-view [String]
+  [^String view-name]
+  (drop-global-temp-view @defaults/spark view-name))
+(defmethod drop-global-temp-view [SparkSession String]
+  [^SparkSession spark ^String view-name]
+  (drop-global-temp-view (catalog spark) view-name))
+(defmethod drop-global-temp-view [Catalog String]
+  [^Catalog catalog ^String view-name]
+  (. catalog dropGlobalTempView view-name))
+
+
+(defmulti cached? ^Boolean catalog-dispatch)
+(defmethod cached? [String]
+  [^String table-name]
+  (cached? @defaults/spark table-name))
+(defmethod cached? [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (cached? (catalog spark) table-name))
+(defmethod cached? [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog isCached table-name))
+
+
+(defmulti list-columns ^Dataset catalog-dispatch)
+(defmethod list-columns [String]
+  [^String table-name]
+  (list-columns @defaults/spark table-name))
+(defmethod list-columns [String String]
+  [^String db-name ^String table-name]
+  (list-columns @defaults/spark db-name table-name))
+(defmethod list-columns [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (list-columns (catalog spark) table-name))
+(defmethod list-columns [SparkSession String String]
+  [^SparkSession spark ^String db-name ^String table-name]
+  (list-columns (catalog spark) db-name table-name))
+(defmethod list-columns [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog listColumns table-name))
+(defmethod list-columns [Catalog String String]
+  [^Catalog catalog ^String db-name ^String table-name]
+  (. catalog listColumns db-name table-name))
+
+
+(defmulti list-databases ^Dataset catalog-dispatch)
+(defmethod list-databases []
+  []
+  (list-databases @defaults/spark))
+(defmethod list-databases [SparkSession]
+  [^SparkSession spark]
+  (list-databases (catalog spark)))
+(defmethod list-databases [Catalog]
+  [^Catalog catalog]
+  (. catalog listDatabases))
+
+
+(defmulti list-tables ^Dataset catalog-dispatch)
+(defmethod list-tables []
+  []
+  (list-tables @defaults/spark))
+(defmethod list-tables [SparkSession]
+  [^SparkSession spark]
+  (list-tables (catalog spark)))
+(defmethod list-tables [Catalog]
+  [^Catalog catalog]
+  (. catalog listTables))
+(defmethod list-tables [String]
+  [^String db-name]
+  (list-tables @defaults/spark db-name))
+(defmethod list-tables [SparkSession String]
+  [^SparkSession spark ^String db-name]
+  (list-tables (catalog spark) db-name))
+(defmethod list-tables [Catalog String]
+  [^Catalog catalog ^String db-name]
+  (. catalog listTables db-name))
+
+
+(defmulti recover-partitions catalog-dispatch)
+(defmethod recover-partitions [String]
+  [^String table-name]
+  (recover-partitions @defaults/spark table-name))
+(defmethod recover-partitions [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (recover-partitions (catalog spark) table-name))
+(defmethod recover-partitions [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog recoverPartitions table-name))
+
+
+(defmulti refresh-by-path catalog-dispatch)
+(defmethod refresh-by-path [String]
+  [^String path]
+  (refresh-by-path @defaults/spark path))
+(defmethod refresh-by-path [SparkSession String]
+  [^SparkSession spark ^String path]
+  (refresh-by-path (catalog spark) path))
+(defmethod refresh-by-path [Catalog String]
+  [^Catalog catalog ^String path]
+  (. catalog refreshByPath path))
+
+
+(defmulti refresh-table catalog-dispatch)
+(defmethod refresh-table [String]
+  [^String table-name]
+  (refresh-table @defaults/spark table-name))
+(defmethod refresh-table [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (refresh-table (catalog spark) table-name))
+(defmethod refresh-table [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog refreshTable table-name))
+
+
+(defmulti set-current-database catalog-dispatch)
+(defmethod set-current-database [String]
+  [^String db-name]
+  (set-current-database @defaults/spark db-name))
+(defmethod set-current-database [SparkSession String]
+  [^SparkSession spark ^String db-name]
+  (set-current-database (catalog spark) db-name))
+(defmethod set-current-database [Catalog String]
+  [^Catalog catalog ^String db-name]
+  (. catalog setCurrentDatabase db-name))
+
+
+(defmulti table-exists? ^Boolean catalog-dispatch)
+(defmethod table-exists? [String]
+  [^String table-name]
+  (table-exists? @defaults/spark table-name))
+(defmethod table-exists? [String String]
+  [^String db-name ^String table-name]
+  (table-exists? @defaults/spark db-name table-name))
+(defmethod table-exists? [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (table-exists? (catalog spark) table-name))
+(defmethod table-exists? [SparkSession String String]
+  [^SparkSession spark ^String db-name ^String table-name]
+  (table-exists? (catalog spark) db-name table-name))
+(defmethod table-exists? [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog tableExists table-name))
+(defmethod table-exists? [Catalog String String]
+  [^Catalog catalog ^String db-name ^String table-name]
+  (. catalog tableExists db-name table-name))
+
+
+(defmulti uncache-table catalog-dispatch)
+(defmethod uncache-table [String]
+  [^String table-name]
+  (uncache-table @defaults/spark table-name))
+(defmethod uncache-table [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (uncache-table (catalog spark) table-name))
+(defmethod uncache-table [Catalog String]
+  [^Catalog catalog ^String table-name]
+  (. catalog uncacheTable table-name))
+
+
+(defmulti drop-relation catalog-dispatch)
+(defmethod drop-relation [Keyword String]
+  [^Keyword relation-type ^String table-name]
+  (drop-relation @defaults/spark relation-type table-name false))
+(defmethod drop-relation [Keyword String Boolean]
+  [^Keyword relation-type ^String table-name ^Boolean if-exists]
+  (drop-relation @defaults/spark relation-type table-name if-exists))
+(defmethod drop-relation [Keyword String String]
+  [^Keyword relation-type ^String db-name ^String table-name]
+  (drop-relation @defaults/spark relation-type db-name table-name false))
+(defmethod drop-relation [Keyword String String Boolean]
+  [^Keyword relation-type ^String db-name ^String table-name ^Boolean if-exists]
+  (drop-relation @defaults/spark relation-type db-name table-name if-exists))
+(defmethod drop-relation [SparkSession Keyword String]
+  [^SparkSession spark ^Keyword relation-type ^String table-name]
+  (drop-relation spark relation-type table-name false))
+(defmethod drop-relation [SparkSession Keyword String Boolean]
+  [^SparkSession spark ^Keyword relation-type ^String table-name ^Boolean if-exists]
+  (-> spark
+      (. sql (str "DROP "
+                  (name relation-type) " "
+                  (when if-exists "IF EXISTS ")
+                  table-name))))
+(defmethod drop-relation [SparkSession Keyword String String]
+  [^SparkSession spark ^Keyword relation-type ^String db-name ^String table-name]
+  (drop-relation spark relation-type (table-identifier db-name table-name) false))
+(defmethod drop-relation [SparkSession Keyword String String Boolean]
+  [^SparkSession spark ^Keyword relation-type ^String db-name ^String table-name ^Boolean if-exists]
+  (drop-relation spark relation-type (table-identifier db-name table-name) if-exists))
+
+
+(defmulti drop-table catalog-dispatch)
+(defmethod drop-table [String]
+  [^String table-name]
+  (drop-table @defaults/spark table-name false))
+(defmethod drop-table [String Boolean]
+  [^String table-name ^Boolean if-exists]
+  (drop-table @defaults/spark table-name if-exists))
+(defmethod drop-table [String String]
+  [^String db-name ^String table-name]
+  (drop-table @defaults/spark db-name table-name false))
+(defmethod drop-table [String String Boolean]
+  [^String db-name ^String table-name ^Boolean if-exists]
+  (drop-table @defaults/spark db-name table-name if-exists))
+(defmethod drop-table [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (drop-relation spark :TABLE table-name false))
+(defmethod drop-table [SparkSession String Boolean]
+  [^SparkSession spark ^String table-name ^Boolean if-exists]
+  (drop-relation spark :TABLE table-name if-exists))
+(defmethod drop-table [SparkSession String String]
+  [^SparkSession spark ^String db-name ^String table-name]
+  (drop-relation spark :TABLE db-name table-name false))
+(defmethod drop-table [SparkSession String String Boolean]
+  [^SparkSession spark ^String db-name ^String table-name ^Boolean if-exists]
+  (drop-relation spark :TABLE db-name table-name if-exists))
+
+
+(defmulti drop-view catalog-dispatch)
+(defmethod drop-view [String]
+  [^String table-name]
+  (drop-view @defaults/spark table-name false))
+(defmethod drop-view [String Boolean]
+  [^String table-name ^Boolean if-exists]
+  (drop-view @defaults/spark table-name if-exists))
+(defmethod drop-view [String String]
+  [^String db-name ^String table-name]
+  (drop-view @defaults/spark db-name table-name false))
+(defmethod drop-view [String String Boolean]
+  [^String db-name ^String table-name ^Boolean if-exists]
+  (drop-view @defaults/spark db-name table-name if-exists))
+(defmethod drop-view [SparkSession String]
+  [^SparkSession spark ^String table-name]
+  (drop-relation spark :VIEW table-name false))
+(defmethod drop-view [SparkSession String Boolean]
+  [^SparkSession spark ^String table-name ^Boolean if-exists]
+  (drop-relation spark :VIEW table-name if-exists))
+(defmethod drop-view [SparkSession String String]
+  [^SparkSession spark ^String db-name ^String table-name]
+  (drop-relation spark :VIEW db-name table-name false))
+(defmethod drop-view [SparkSession String String Boolean]
+  [^SparkSession spark ^String db-name ^String table-name ^Boolean if-exists]
+  (drop-relation spark :VIEW db-name table-name if-exists))

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -513,6 +513,10 @@
 (import-vars
   [zero-one.geni.core.data-sources
    ->kebab-columns
+   create-temp-view!
+   create-or-replace-temp-view!
+   create-global-temp-view!
+   create-or-replace-global-temp-view!
    read-avro!
    read-csv!
    read-edn!
@@ -520,6 +524,7 @@
    read-json!
    read-libsvm!
    read-parquet!
+   read-table!
    read-text!
    read-xlsx!
    write-avro!
@@ -529,6 +534,7 @@
    write-json!
    write-libsvm!
    write-parquet!
+   write-table!
    write-text!
    write-xlsx!])
 

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -51,6 +51,7 @@
                             rand
                             rand-int
                             rand-nth
+                            range
                             remove
                             rename-keys
                             reverse
@@ -398,6 +399,7 @@
    create-dataframe
    map->dataset
    map-type
+   range
    records->dataset
    struct-field
    struct-type

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -94,7 +94,8 @@
 (import-vars
   [zero-one.geni.spark
    create-spark-session
-   spark-conf])
+   spark-conf
+   sql])
 
 (import-vars
   [zero-one.geni.spark-context

--- a/src/clojure/zero_one/geni/defaults.clj
+++ b/src/clojure/zero_one/geni/defaults.clj
@@ -2,10 +2,12 @@
   (:require
     [zero-one.geni.spark]))
 
+(def session-config
+  {:configs {:spark.sql.adaptive.enabled "true"
+             :spark.sql.adaptive.coalescePartitions.enabled "true"}
+   :checkpoint-dir "target/checkpoint/"})
+
 (def spark
   "The default SparkSession as a Delayed object."
-  (delay
-    (zero-one.geni.spark/create-spark-session
-      {:configs {:spark.sql.adaptive.enabled "true"
-                 :spark.sql.adaptive.coalescePartitions.enabled "true"}
-       :checkpoint-dir "target/checkpoint/"})))
+  (atom
+    (zero-one.geni.spark/create-spark-session session-config)))

--- a/src/clojure/zero_one/geni/spark.clj
+++ b/src/clojure/zero_one/geni/spark.clj
@@ -43,6 +43,17 @@
        .getConf
        interop/spark-conf->map))
 
+(defn sql
+  "Executes a SQL query using Spark, returning the result as a `DataFrame`.
+
+  The dialect that is used for SQL parsing can be configured with 'spark.sql.dialect'.
+
+  ```clojure
+  (g/sql spark \"SELECT * FROM my_table\")
+  ```"
+  [^SparkSession spark ^String sql-text]
+  (. spark sql sql-text))
+
 ;; Docs
 (docs/add-doc!
   (var spark-conf)

--- a/test/zero_one/geni/catalog_test.clj
+++ b/test/zero_one/geni/catalog_test.clj
@@ -1,0 +1,313 @@
+(ns zero-one.geni.catalog-test
+  (:require [midje.sweet :refer [facts fact => throws with-state-changes after before]]
+            [zero-one.geni.catalog :as c]
+            [zero-one.geni.core :as g]
+            [zero-one.geni.test-resources :as tr]
+            [clojure.string :as string])
+  (:import (org.apache.spark.sql AnalysisException)
+           (org.apache.spark.sql.catalog Catalog)
+           (java.nio.file Paths)))
+
+
+(defn create-test-db []
+  (g/sql @tr/spark "CREATE DATABASE IF NOT EXISTS test_db"))
+
+
+(facts "On getting the default catalog"
+  (instance? Catalog (c/catalog)) => true)
+
+(facts "On cache management"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Should (un)cache tables"
+      (let [df (g/range 1)]
+        (create-test-db)
+        (g/write-table! df "tbl")
+        (g/write-table! df "test_db.tbl"))
+      (c/cache-table "tbl")
+      (c/cache-table @tr/spark "test_db.tbl")
+      (c/cached? @tr/spark "tbl") => true
+      (c/cached? "test_db.tbl") => true
+      (c/uncache-table "tbl")
+      (c/uncache-table "test_db.tbl")
+      (c/cached? @tr/spark "tbl") => false
+      (c/cached? "test_db.tbl") => false
+      (c/cache-table "tbl")
+      (c/cache-table "test_db.tbl")
+      (c/clear-cache)
+      (c/cached? "tbl") => false
+      (c/cached? "test_db.tbl") => false)))
+
+
+(facts "On database management"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Should change databases"
+      (create-test-db)
+      (c/current-database) => "default"
+      (c/set-current-database "test_db")
+      (c/current-database @tr/spark) => "test_db"
+      (c/set-current-database @tr/spark "default")
+      (c/database-exists? "test_db") => true
+      (c/database-exists? @tr/spark "default") => true)
+    (fact "Should know what databases exist"
+      (-> @tr/spark
+          c/list-databases
+          g/to-df
+          (g/drop :locationUri)
+          g/collect)
+      => [{:name        "default"
+           :description "default database"}]
+      (create-test-db)
+      (-> (c/list-databases)
+          g/to-df
+          (g/drop :locationUri)
+          g/collect)
+      => [{:name        "default"
+           :description "default database"}
+          {:name        "test_db"
+           :description ""}])))
+
+
+(facts "On table management"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Should know what tables exist")
+    (fact "Should know what columns exist")
+    (fact "")))
+
+
+(facts "On table management"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Know what tables exist"
+      (let [df1 (g/range 3)]
+        (g/write-table! df1 "tbl1")
+        (c/table-exists? "tbl1") => true
+        (-> (c/list-tables)
+            g/to-df
+            g/collect)
+        => [{:name        "tbl1"
+             :database    "default"
+             :description nil
+             :tableType   "MANAGED"
+             :isTemporary false}]
+        (c/drop-table "tbl1")
+        (c/drop-table "i_dont_exist" true)
+        (-> (c/list-tables)
+            g/to-df
+            g/collect)
+        => [])
+      (fact "Know how to cache and un-cache tables"
+        (let [df1 (g/range 3)]
+          (c/uncache-table @tr/spark "tbl1") => (throws AnalysisException)
+          (g/write-table! df1 "tbl1")
+          (c/cache-table "tbl1")
+          (c/cached? "tbl1") => true
+          (c/uncache-table "tbl1")
+          (c/cached? "tbl1") => false
+          (c/cache-table "tbl1" g/memory-only)
+          (c/cached? "tbl1") => true
+          (c/clear-cache)
+          (c/cached? "tbl1") => false)))))
+
+
+(facts "On view management"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Create and drop temp views"
+      (let [df (g/range 1)]
+        (g/create-temp-view! df "view1")
+        (g/create-global-temp-view! df "view2")
+        (c/table-exists? "global_temp" "view2") => true
+        (-> (c/list-tables "global_temp")
+            g/to-df
+            g/collect)
+        => [{:name        "view2"
+             :database    "global_temp"
+             :description nil
+             :tableType   "TEMPORARY"
+             :isTemporary true}
+            {:name        "view1"
+             :database    nil
+             :description nil
+             :tableType   "TEMPORARY"
+             :isTemporary true}]
+        (c/drop-temp-view "view1")
+        (c/drop-global-temp-view "view2")
+        (c/table-exists? @tr/spark "default" "view1") => false
+        (c/table-exists? @tr/spark "view2") => false))
+    (fact "Replace temp views"
+      (let [df1 (g/range 1)
+            df2 (g/range 2)]
+        (g/create-temp-view! df1 "view1")
+        (g/create-global-temp-view! df1 "view2")
+        (g/create-or-replace-temp-view! df2 "view1")
+        (g/create-or-replace-global-temp-view! df2 "view2")
+        (g/count (g/read-table! "view1")) => 2
+        (g/count (g/read-table! "global_temp.view2")) => 2))))
+
+
+(facts "On exploring columns"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))])
+  (fact "list column in tables from any database"
+    (let [df1 (g/range 3)
+          df2 (g/with-column df1 :is_odd (g/mod :id 2))]
+      (create-test-db)
+      (g/write-table! df1 "tbl1")
+      (g/write-table! df2 "tbl2")
+      (g/write-table! df2 "test_db.tbl2")
+      (-> (g/union (c/list-columns @tr/spark "tbl1")
+                   (c/list-columns "tbl2")
+                   (c/list-columns "test_db" "tbl2"))
+          (g/order-by :name)
+          g/to-df
+          g/collect)
+      => (concat (repeat 3 {:name        "id"
+                            :description nil
+                            :dataType    "bigint"
+                            :nullable    true
+                            :isPartition false
+                            :isBucket    false})
+                 (repeat 2 {:name        "is_odd"
+                            :description nil
+                            :dataType    "bigint"
+                            :nullable    true
+                            :isPartition false
+                            :isBucket    false})))))
+
+
+(facts "On drop"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Drop tables"
+      (let [df (g/range 1)]
+        (g/write-table! df "tbl")
+        (c/drop-table "tbl")
+        (c/table-exists? "tbl") => false
+
+        (g/write-table! df "tbl")
+        (c/drop-table "default" "tbl")
+        (c/table-exists? "default" "tbl") => false
+
+        (g/write-table! df "tbl")
+        (c/drop-table @tr/spark "tbl")
+        (c/table-exists? "tbl") => false
+
+        (g/write-table! df "tbl")
+        (c/drop-table @tr/spark "default" "tbl")
+        (c/table-exists? "default" "tbl") => false
+
+        (c/drop-table "tbl" true)
+        (c/drop-table "tbl") => (throws AnalysisException)
+
+        (c/drop-table "default" "tbl" true)
+        (c/drop-table "default" "tbl") => (throws AnalysisException)
+
+        (c/drop-table @tr/spark "tbl" true)
+        (c/drop-table @tr/spark "tbl") => (throws AnalysisException)
+
+        (c/drop-table @tr/spark "default" "tbl" true)
+        (c/drop-table @tr/spark "default" "tbl") => (throws AnalysisException)))
+    (fact "Drop views"
+      (let [df (g/range 1)
+            create-view #(g/sql @tr/spark (str "CREATE VIEW " % " AS SELECT * FROM tbl"))]
+        (g/write-table! df "tbl")
+
+        (create-view "v")
+        (c/drop-view "v")
+        (c/table-exists? "v") => false
+
+        (create-view "v")
+        (c/drop-view "default" "v")
+        (c/table-exists? "default" "v") => false
+
+        (create-view "v")
+        (c/drop-view @tr/spark "v")
+        (c/table-exists? "v") => false
+
+        (create-view "v")
+        (c/drop-view @tr/spark "default" "v")
+        (c/table-exists? "default" "v") => false
+
+        (c/drop-view "v" true)
+        (c/drop-view "v") => (throws AnalysisException)
+
+        (c/drop-view "default" "v" true)
+        (c/drop-view "default" "v") => (throws AnalysisException)
+
+        (c/drop-view @tr/spark "v" true)
+        (c/drop-view @tr/spark "v") => (throws AnalysisException)
+
+        (c/drop-view @tr/spark "default" "v" true)
+        (c/drop-view @tr/spark "default" "v") => (throws AnalysisException)))
+    (fact "Drop relations"
+      (let [df (g/range 1)
+            create-view #(g/sql @tr/spark (str "CREATE VIEW " % " AS SELECT * FROM tbl"))]
+        (g/write-table! df "tbl")
+        (create-view "v")
+
+        (c/drop-relation :VIEW "v")
+        (c/table-exists? "v") => false
+
+        (c/drop-relation :TABLE "default" "tbl")
+        (c/table-exists? "default" "tbl") => false
+
+        (g/write-table! df "tbl")
+        (create-view "v")
+
+        (c/drop-relation @tr/spark :VIEW "v")
+        (c/table-exists? "v") => false
+
+        (c/drop-relation @tr/spark :TABLE "default" "tbl")
+        (c/table-exists? "default" "tbl") => false
+
+        (c/drop-relation :VIEW "v" true)
+        (c/drop-relation :TABLE "tbl" true)
+        (c/drop-relation :TABLE "default" "tbl" true)
+        (c/drop-relation :VIEW "v") => (throws AnalysisException)
+        (c/drop-relation :TABLE "tbl") => (throws AnalysisException)))))
+
+
+(defn table-partition-path
+  [spark table partition-col partition-val]
+  (Paths/get (-> spark
+                 .conf
+                 (.get "spark.sql.warehouse.dir")
+                 (string/replace "file:" ""))
+             (into-array String [table (str (name partition-col) "=" partition-val)])))
+
+
+(facts "On refresh"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Adapt to change of table files"
+      (-> (g/range 6)
+          (g/with-column :is_odd (g/mod :id 2))
+          (g/write-table! "tbl" {:partition-by :is_odd}))
+      (let [df (-> (g/read-table! "tbl") (g/order-by :id) (g/cache))]
+        (tr/recursive-delete-dir (.toFile (table-partition-path @tr/spark "tbl" :is_odd 1)))
+        ;(g/collect df) => (throws FileNotFoundException)  // @note I think will throw when not using local metastore.
+        (c/refresh-table "tbl")
+        (g/collect df) => [{:id 0 :is_odd 0} {:id 2 :is_odd 0} {:id 4 :is_odd 0}]))
+    (fact "Adapt to change in data files"
+      (let [tmp-dir (tr/create-temp-dir!)
+            path (str (.resolve (.toPath tmp-dir) "my_dataset"))]
+        (-> (g/range 6)
+            (g/with-column :is_odd (g/mod :id 2))
+            (g/write-parquet! path {:partition-by :is_odd}))
+        (let [df (-> (g/read-parquet! path) (g/order-by :id) (g/cache))
+              partition-path (Paths/get path (into-array String ["is_odd=1"]))]
+          (tr/recursive-delete-dir (.toFile partition-path))
+          (c/refresh-by-path path)
+          (g/collect df) => [{:id 0 :is_odd 0} {:id 2 :is_odd 0} {:id 4 :is_odd 0}])))
+    (fact "Recover partitions"
+      (-> (g/range 6)
+          (g/with-column :is_odd (g/mod :id 2))
+          (g/write-table! "tbl" {:partition-by :is_odd}))
+      (let [df (-> (g/read-table! "tbl") (g/order-by :id) (g/cache))
+            partition-path (table-partition-path @tr/spark "tbl" :is_odd 1)]
+        (tr/recursive-delete-dir (.toFile partition-path))
+        (c/recover-partitions "tbl")
+        (g/collect df) => [{:id 0 :is_odd 0} {:id 2 :is_odd 0} {:id 4 :is_odd 0}]))))

--- a/test/zero_one/geni/clojure_idioms_test.clj
+++ b/test/zero_one/geni/clojure_idioms_test.clj
@@ -2,15 +2,15 @@
   (:require
     [midje.sweet :refer [fact =>]]
     [zero-one.geni.core :as g]
-    [zero-one.geni.test-resources :refer [df-20]]))
+    [zero-one.geni.test-resources :refer [spark df-20]]))
 
 (fact "On update"
-  (-> (g/table->dataset (mapv vector (range 5)) [:i])
+  (-> (g/table->dataset @spark (mapv vector (range 5)) [:i])
       (g/update :i g/+ 1 2 3)
       (g/collect-col :i)) => [6 7 8 9 10])
 
 (fact "On cond" :slow
-  (-> df-20
+  (-> (df-20)
       (g/with-column :cond (g/cond
                              (g/< :Price 8e5) (g/lit "low")
                              (g/< :Price 1e6) (g/lit "medium")
@@ -19,7 +19,7 @@
       set) => #{"high" "medium" "low"})
 
 (fact "On condp" :slow
-  (-> (g/table->dataset (mapv vector (range 1 16)) [:idx])
+  (-> (g/table->dataset @spark (mapv vector (range 1 16)) [:idx])
       (g/with-column :fb (g/condp #(g/zero? (g/mod %2 %1)) :idx
                            15 (g/lit "fizzbuzz")
                            5 (g/lit "buzz")
@@ -40,7 +40,7 @@
                      {:idx 13, :fb "13"}
                      {:idx 14, :fb "14"}
                      {:idx 15, :fb "fizzbuzz"}]
-  (-> (g/table->dataset (mapv vector (range 1 16)) [:idx])
+  (-> (g/table->dataset @spark (mapv vector (range 1 16)) [:idx])
       (g/with-column :fb (g/condp #(g/zero? (g/mod %2 %1)) :idx
                            15 (g/lit "fizzbuzz")
                            5 (g/lit "buzz")
@@ -55,7 +55,7 @@
                      {:fb "fizzbuzz" :idx 15}])
 
 (fact "On case" :slow
-  (-> df-20
+  (-> (df-20)
       (g/limit 10)
       (g/with-column :case (g/case :SellerG
                              (g/lit "Biggin") 0
@@ -66,7 +66,7 @@
       set) => #{{:SellerG "Biggin" :case 0}
                 {:SellerG "Jellis" :case 2}
                 {:SellerG "Nelson" :case 1}}
-  (-> df-20
+  (-> (df-20)
       (g/limit 10)
       (g/with-column :case (g/case :SellerG
                              (g/lit "Biggin") 0
@@ -76,7 +76,7 @@
       set) => #{{:SellerG "Biggin" :case 0}
                 {:SellerG "Jellis" :case nil}
                 {:SellerG "Nelson" :case 1}}
-  (-> df-20
+  (-> (df-20)
       (g/limit 10)
       (g/with-column :case (g/case :SellerG
                              (g/lit "Jellis") 0
@@ -89,7 +89,7 @@
                 {:SellerG "Nelson" :case 1}})
 
 (fact "On if" :slow
-  (-> df-20
+  (-> (df-20)
       (g/with-column :if (g/if (g/< :Price 1e6)
                            (g/lit "high")
                            (g/lit "low")))

--- a/test/zero_one/geni/column_test.clj
+++ b/test/zero_one/geni/column_test.clj
@@ -11,13 +11,13 @@
   => "lead('Suburb, 2, null)\n")
 
 (fact "On hash-code"
-  (-> df-1
+  (-> (df-1)
       (g/select (g/hash-code :Suburb))
       g/collect-vals
       ffirst) => int?)
 
 (fact "On get-field and get-item"
-  (-> df-1
+  (-> (df-1)
       (g/with-column :x (g/struct {:s :SellerG :p :Price}))
       (g/with-column :xs [-1.0 -2.0])
       (g/select
@@ -28,7 +28,7 @@
 
 (facts "On comparison and boolean functions" :slow
   (fact "null checks"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/not-null? nil)
           (g/not-null? 1)
@@ -36,14 +36,14 @@
           (g/null? 1))
         g/collect-vals) => [[false true true false]])
   (fact "bitwise operations"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/& 3 5)
           (g/| 3 5)
           (g/bitwise-xor 3 5))
         g/collect-vals) => [[1 7 6]])
   (fact "operations on maps"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/&& {:a true  :b true})
           (g/&& {:a true  :b false})
@@ -51,13 +51,13 @@
           (g/|| {:a true  :b false}))
         g/collect-vals) => [[true false false true]])
   (fact "zero-arity calls"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/&&)
           (g/||))
         g/collect-vals) => [[true false]])
   (fact "rare comparison functions"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/<=> 0 1)
           (g/<=> 1 1)
@@ -67,7 +67,7 @@
           (g/=!= 1 0))
         g/collect-vals) => [[false true false nil false true]])
   (fact "common comparison functions"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/< 1)
           (g/< 1 2 3)
@@ -78,32 +78,32 @@
           (g/|| true false))
         g/collect-vals) => [[true true true false false false true]])
   (fact "is in collection"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/is-in-collection 1 [1 2])
           (g/is-in-collection 1 [2 3]))
         g/collect-vals) => [[true false]]))
 
 (fact "On sorting functions" :slow
-  (-> df-20
+  (-> (df-20)
       (g/order-by (g/asc-nulls-first :BuildingArea))
       (g/collect-col :BuildingArea)
       first) => nil?
-  (-> df-20
+  (-> (df-20)
       (g/order-by (g/asc-nulls-last :BuildingArea))
       (g/collect-col :BuildingArea)
       last) => nil?
-  (-> df-20
+  (-> (df-20)
       (g/order-by (g/desc-nulls-first :BuildingArea))
       (g/collect-col :BuildingArea)
       first) => nil?
-  (-> df-20
+  (-> (df-20)
       (g/order-by (g/desc-nulls-last :BuildingArea))
       (g/collect-col :BuildingArea)
       last) => nil?)
 
 (fact "On clojure idioms" :slow
-  (-> df-1
+  (-> (df-1)
       (g/select
         (g/inc 1)
         (g/dec 1)
@@ -114,7 +114,7 @@
         (g/even? 1)
         (g/odd? 1))
       g/collect-vals) => [[2 0 true false true false false true]]
-  (-> df-1
+  (-> (df-1)
       (g/select
         {:a (g/short 1.0)
          :b (g/int 1.0)
@@ -136,34 +136,34 @@
   (fact "rlike should filter correctly"
     (let [includes-east-or-north? #(or (clojure.string/includes? % "East")
                                        (clojure.string/includes? % "North"))]
-      (-> melbourne-df
+      (-> (melbourne-df)
           (g/filter (g/rlike :Suburb ".(East|North)"))
           (g/select :Suburb)
           g/distinct
           (g/collect-col :Suburb)) => #(every? includes-east-or-north? %)))
   (fact "like should filter correctly"
     (let [includes-south? #(clojure.string/includes? % "South")]
-      (-> melbourne-df
+      (-> (melbourne-df)
           (g/filter (g/like :Suburb "%South%"))
           (g/select :Suburb)
           g/distinct
           (g/collect-col :Suburb)) => #(every? includes-south? %)))
   (fact "contains should filter correctly"
     (let [includes-west? #(clojure.string/includes? % "West")]
-      (-> melbourne-df
+      (-> (melbourne-df)
           (g/filter (g/contains :Suburb "West"))
           (g/select :Suburb)
           g/distinct
           (g/collect-col :Suburb)) => #(every? includes-west? %)))
   (fact "starts-with should filter correctly"
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/filter (g/starts-with :Suburb "East"))
         (g/select :Suburb)
         g/distinct
         (g/collect-col :Suburb)) => ["East Melbourne"])
   (fact "starts-with should filter correctly"
     (let [ends-with-west? #(= (last (clojure.string/split % #" ")) "West")]
-      (-> melbourne-df
+      (-> (melbourne-df)
           (g/filter (g/ends-with :Suburb "West"))
           (g/select :Suburb)
           g/distinct

--- a/test/zero_one/geni/data_sources_test.clj
+++ b/test/zero_one/geni/data_sources_test.clj
@@ -1,7 +1,6 @@
 (ns zero-one.geni.data-sources-test
   (:require
     [clojure.edn :as edn]
-    [clojure.test :refer :all]
     [midje.sweet :refer [facts fact => throws with-state-changes before after]]
     [zero-one.geni.core :as g]
     [zero-one.geni.catalog :as c]
@@ -285,5 +284,5 @@
       (let [dataset (g/range 3)
             table-name "tbl"]
         (g/write-table! dataset table-name)
-        (c/table-exists (c/catalog @spark) "tbl") => true
+        (c/table-exists? (c/catalog @spark) "tbl") => true
         (g/collect (g/order-by (g/read-table! table-name) :id)) => (g/collect (g/order-by (g/to-df dataset) :id))))))

--- a/test/zero_one/geni/data_sources_test.clj
+++ b/test/zero_one/geni/data_sources_test.clj
@@ -1,19 +1,24 @@
 (ns zero-one.geni.data-sources-test
   (:require
     [clojure.edn :as edn]
-    [midje.sweet :refer [facts fact => throws]]
+    [clojure.test :refer :all]
+    [midje.sweet :refer [facts fact => throws with-state-changes before after]]
     [zero-one.geni.core :as g]
+    [zero-one.geni.catalog :as c]
     [zero-one.geni.test-resources :refer [create-temp-file!
                                           melbourne-df
-                                          libsvm-df]])
+                                          libsvm-df
+                                          spark
+                                          reset-session!
+                                          delete-warehouse!]])
   (:import
     (org.apache.spark.sql AnalysisException)))
 
 (def write-df
-  (-> melbourne-df (g/select :Method :Type) (g/limit 5)))
+  (-> (melbourne-df) (g/select :Method :Type) (g/limit 5)))
 
 (facts "On data-oriented schema" :schema
-  (let [dummy-df (-> melbourne-df
+  (let [dummy-df (-> (melbourne-df)
                      (g/limit 2)
                      g/->kebab-columns
                      (g/select {:rooms (g/struct :rooms :bathroom)
@@ -30,6 +35,7 @@
                                           "StructField(bathroom,DoubleType,true))")})
     (fact "correct direct schema option"
       (-> (g/read-parquet!
+            @spark
             temp-file
             {:schema (g/struct-type
                        (g/struct-field :rooms
@@ -46,6 +52,7 @@
                                     "StructField(bathroom,FloatType,true))")})
     (fact "correct data-oriented schema option"
       (-> (g/read-parquet!
+            @spark
             temp-file
             {:schema {:coord [:short]
                       :prop  [:string :string]
@@ -60,17 +67,17 @@
   (let [csv-path "test/resources/sample_csv_data.csv"
         selected [:InvoiceDate :Price]]
     (fact "correct schemaless baseline"
-      (-> (g/read-csv! csv-path)
+      (-> (g/read-csv! @spark csv-path)
           (g/select selected)
           g/dtypes) => {:InvoiceDate "StringType" :Price "DoubleType"})
     (fact "correct direct schema option"
-      (-> (g/read-csv! csv-path {:schema (g/struct-type
-                                           (g/struct-field :InvoiceDate :date true)
-                                           (g/struct-field :Price :int true))})
+      (-> (g/read-csv! @spark csv-path {:schema (g/struct-type
+                                                  (g/struct-field :InvoiceDate :date true)
+                                                  (g/struct-field :Price :int true))})
           (g/select selected)
           g/dtypes) => {:InvoiceDate "DateType" :Price "IntegerType"})
     (fact "correct data-oriented schema option"
-      (-> (g/read-csv! csv-path {:schema {:InvoiceDate :date :Price :long}})
+      (-> (g/read-csv! @spark csv-path {:schema {:InvoiceDate :date :Price :long}})
           (g/select selected)
           g/dtypes) => {:InvoiceDate "DateType" :Price "LongType"})))
 
@@ -78,18 +85,18 @@
   (let [temp-file  (.toString (create-temp-file! ".xlsx"))
         read-df    (do
                      (g/write-xlsx! write-df temp-file {:mode "overwrite"})
-                     (g/read-xlsx! temp-file))
-        headerless (g/read-xlsx! temp-file {:header false :kebab-columns true})]
+                     (g/read-xlsx! @spark temp-file))
+        headerless (g/read-xlsx! @spark temp-file {:header false :kebab-columns true})]
     (fact "read and write xlsx work"
       (g/collect read-df) => (g/collect write-df)
       (g/write-xlsx! write-df temp-file) => (throws Exception))
     (fact "read edge cases"
-      (g/read-xlsx! temp-file {:sheet "Sheet2"}) => g/empty?
+      (g/read-xlsx! @spark temp-file {:sheet "Sheet2"}) => g/empty?
       (g/count headerless) => 6
       (g/first headerless) => {:c-0 "Method" :c-1 "Type"})))
 
 (facts "On edn" :edn
-  (let [write-df  (-> melbourne-df (g/select :Price :Rooms) (g/limit 3))
+  (let [write-df  (-> (melbourne-df) (g/select :Price :Rooms) (g/limit 3))
         temp-file (.toString (create-temp-file! ".edn"))]
     (fact "write-edn! works as expected"
       (g/write-edn! write-df temp-file {:mode "overwrite"})
@@ -98,21 +105,22 @@
                                               {:Price 1465000.0 :Rooms 3}]
       (g/write-edn! write-df temp-file) => (throws Exception))
     (fact "read-edn! works as expected"
-      (g/collect (g/read-edn! temp-file)) => [{:Price 1480000.0 :Rooms 2}
-                                              {:Price 1035000.0 :Rooms 2}
-                                              {:Price 1465000.0 :Rooms 3}]
-      (g/column-names (g/read-edn! temp-file {:kebab-columns true}))
+      (g/collect (g/read-edn! @spark temp-file)) => [{:Price 1480000.0 :Rooms 2}
+                                                     {:Price 1035000.0 :Rooms 2}
+                                                     {:Price 1465000.0 :Rooms 3}]
+      (g/column-names (g/read-edn! @spark temp-file {:kebab-columns true}))
       => ["price" "rooms"])))
 
 (facts "On options" :slow
   (fact "infer-schema can be turned off"
-    (let [write-df  (-> melbourne-df (g/select :Price :Rooms) (g/limit 5))
+    (let [write-df  (-> (melbourne-df) (g/select :Price :Rooms) (g/limit 5))
           temp-file (.toString (create-temp-file! ".csv"))
           read-df  (do (g/write-csv! write-df temp-file {:mode "overwrite"})
-                       (g/read-csv! temp-file {:infer-schema false}))]
+                       (g/read-csv! @spark temp-file {:infer-schema false}))]
       (g/dtypes read-df)) => {:Price "StringType" :Rooms "StringType"})
   (fact "kebab-columns option works"
     (let [dataframe (g/table->dataset
+                      @spark
                       [[1 2 3 4]]
                       ["Brébeuf (données non disponibles)"
                        "X Coordinate (State Plane)"
@@ -120,13 +128,12 @@
                        "already-kebab-case"])
           temp-file (.toString (create-temp-file! ""))]
       (g/write-csv! dataframe temp-file {:mode "overwrite"})
-      (g/column-names (g/read-csv! temp-file {:kebab-columns true})))
+      (g/column-names (g/read-csv! @spark temp-file {:kebab-columns true})))
     => ["brebeuf-donnees-non-disponibles"
         "x-coordinate-state-plane"
         "col-with-underscore"
         "already-kebab-case"]
-    (-> "test/resources/melbourne_housing_snapshot.parquet"
-        (g/read-parquet! {:kebab-columns true})
+    (-> (g/read-parquet! @spark "test/resources/melbourne_housing_snapshot.parquet" {:kebab-columns true})
         g/columns) => [:suburb
                        :address
                        :rooms
@@ -161,8 +168,8 @@
         (write-fn! write-df temp-file {:mode "overwrite"})
         (write-fn! write-df temp-file) => (throws AnalysisException))))
   (let [temp-file (.toString (create-temp-file! ""))]
-    (g/write-libsvm! libsvm-df temp-file {:mode "overwrite"})
-    (g/write-libsvm! libsvm-df temp-file) => (throws AnalysisException))
+    (g/write-libsvm! (libsvm-df) temp-file {:mode "overwrite"})
+    (g/write-libsvm! (libsvm-df) temp-file) => (throws AnalysisException))
   (let [write-df  (g/select write-df :Type)
         temp-file (.toString (create-temp-file! ""))
         options   {:driver  "org.sqlite.JDBC"
@@ -173,75 +180,76 @@
 
 (fact "Can read with options" :slow
   (let [read-df (g/read-parquet!
+                  @spark
                   "test/resources/melbourne_housing_snapshot.parquet"
                   {"mergeSchema" "true"})]
     (g/count read-df) => 13580)
   (let [temp-file (.toString (create-temp-file! ".csv"))
         read-df  (do (g/write-csv! write-df temp-file {:mode "overwrite"})
-                     (g/read-csv! temp-file {:header false}))]
+                     (g/read-csv! @spark temp-file {:header false}))]
     (set (g/column-names read-df)) => #(not= % #{:Method :Type}))
   (let [temp-file (.toString (create-temp-file! ".libsvm"))
-        read-df  (do (g/write-libsvm! libsvm-df temp-file {:mode "overwrite"})
-                     (g/read-libsvm! temp-file {:num-features "780"}))]
-    (g/collect read-df) => (g/collect libsvm-df))
+        read-df  (do (g/write-libsvm! (libsvm-df) temp-file {:mode "overwrite"})
+                     (g/read-libsvm! @spark temp-file {:num-features "780"}))]
+    (g/collect read-df) => (g/collect (libsvm-df)))
   (let [temp-file (.toString (create-temp-file! ".json"))
         read-df  (do (g/write-json! write-df temp-file {:mode "overwrite"})
-                     (g/read-json! temp-file {}))]
+                     (g/read-json! @spark temp-file {}))]
     (g/collect write-df) => (g/collect read-df))
   (let [write-df  (g/select write-df :Type)
         temp-file (.toString (create-temp-file! ".txt"))
         read-df  (do (g/write-text! write-df temp-file {:mode "overwrite"})
-                     (g/read-text! temp-file {}))]
+                     (g/read-text! @spark temp-file {}))]
     (g/collect-vals write-df) => (g/collect-vals read-df)))
 
 (fact "Can read and write csv"
   (let [temp-file (.toString (create-temp-file! ".csv"))
         read-df  (do (g/write-csv! write-df temp-file {:mode      "overwrite"
                                                        :delimiter "|"})
-                     (g/read-csv! temp-file {:delimiter "|"}))]
+                     (g/read-csv! @spark temp-file {:delimiter "|"}))]
     (g/collect write-df) => (g/collect read-df))
   (let [temp-file (.toString (create-temp-file! ".csv"))
         read-df  (do (g/write-csv! write-df temp-file {:mode "overwrite"})
-                     (g/read-csv! temp-file))]
+                     (g/read-csv! @spark temp-file))]
     (g/collect write-df) => (g/collect read-df))
   (let [temp-file (.toString (create-temp-file! ".csv"))
         read-df  (do (g/write-csv! write-df temp-file {:mode "overwrite"})
-                     (g/read-csv! temp-file {}))]
+                     (g/read-csv! @spark temp-file {}))]
     (g/column-names read-df) => (g/column-names write-df)))
 
 (fact "Can read and write avro"
   (let [temp-file (.toString (create-temp-file! ".avro"))
         read-df  (do (g/write-avro! write-df temp-file {:mode "overwrite"})
-                     (g/read-avro! temp-file))]
+                     (g/read-avro! @spark temp-file))]
     (g/collect write-df) => (g/collect read-df))
   (let [temp-file (.toString (create-temp-file! ".avro"))
         read-df  (do (g/write-avro! write-df temp-file {:mode "overwrite"})
-                     (g/read-avro! temp-file {}))]
+                     (g/read-avro! @spark temp-file {}))]
     (g/collect write-df) => (g/collect read-df)))
 
 (fact "Can read and write parquet"
   (let [temp-file (.toString (create-temp-file! ".parquet"))
         read-df  (do (g/write-parquet! write-df temp-file {:mode "overwrite"})
-                     (g/read-parquet! temp-file))]
+                     (g/read-parquet! @spark temp-file))]
     (g/collect write-df) => (g/collect read-df)))
 
 (fact "Can read and write libsvm"
   (let [temp-file (.toString (create-temp-file! ".libsvm"))
-        read-df  (do (g/write-libsvm! libsvm-df temp-file {:mode "overwrite"})
-                     (g/read-libsvm! temp-file))]
-    (g/collect libsvm-df) => (g/collect read-df)))
+        read-df  (do (g/write-libsvm! (libsvm-df) temp-file {:mode "overwrite"})
+                     (g/read-libsvm! @spark temp-file))]
+    (g/collect (libsvm-df)) => (g/collect read-df)))
 
 (fact "Can read and write json"
   (let [temp-file (.toString (create-temp-file! ".json"))
         read-df  (do (g/write-json! write-df temp-file {:mode "overwrite"})
-                     (g/read-json! temp-file))]
+                     (g/read-json! @spark temp-file))]
     (g/collect write-df) => (g/collect read-df)))
 
 (fact "Can read and write text"
   (let [write-df  (g/select write-df :Type)
         temp-file (.toString (create-temp-file! ".text"))
         read-df   (do (g/write-text! write-df temp-file {:mode "overwrite"})
-                      (g/read-text! temp-file))]
+                      (g/read-text! @spark temp-file))]
     (g/collect-vals write-df) => (g/collect-vals read-df)))
 
 (fact "Can read and write jdbc" :slow
@@ -252,7 +260,8 @@
                                               :driver  "org.sqlite.JDBC"
                                               :url     (str "jdbc:sqlite:" temp-file)
                                               :dbtable "housing"})
-                    (g/read-jdbc! {:driver  "org.sqlite.JDBC"
+                    (g/read-jdbc! @spark
+                                  {:driver  "org.sqlite.JDBC"
                                    :url     (str "jdbc:sqlite:" temp-file)
                                    :dbtable "housing"}))]
     (g/collect-vals write-df) => (g/collect-vals read-df)))
@@ -263,5 +272,18 @@
                        write-df
                        temp-file
                        {:mode "overwrite" :partition-by [:Method]})
-                     (g/read-parquet! temp-file))]
+                     (g/read-parquet! @spark temp-file))]
     (set (g/collect write-df)) => (set (g/collect read-df))))
+
+(facts "On read/write of managed tables"
+  (with-state-changes [(before :facts (reset-session!))
+                       (after :facts (delete-warehouse!))]
+    (fact "throws if the table doesn't exist."
+      (g/read-table! @spark "i_dont_exist") => (throws AnalysisException))
+
+    (fact "can read and write tables"
+      (let [dataset (g/range 3)
+            table-name "tbl"]
+        (g/write-table! dataset table-name)
+        (c/table-exists (c/catalog @spark) "tbl") => true
+        (g/collect (g/order-by (g/read-table! table-name) :id)) => (g/collect (g/order-by (g/to-df dataset) :id))))))

--- a/test/zero_one/geni/dataset_creation_test.clj
+++ b/test/zero_one/geni/dataset_creation_test.clj
@@ -138,3 +138,19 @@
       (instance? Dataset dataset) => true
       (g/column-names dataset) => ["a" "b" "c"]
       (g/collect-vals dataset) => [[1 2.0 "a"] [4 5.0 "b"]])))
+
+(facts "On spark range"
+  (fact "should create simple datasets"
+    (let [ds (g/range 3)]
+      (g/column-names ds) => ["id"]
+      (g/collect ds) => [0 1 2])
+    (let [ds (g/range 3 5)]
+      (g/column-names ds) => ["id"]
+      (g/collect ds) => [3 4])
+    (let [ds (g/range 10 20 3)]
+      (g/column-names ds) => ["id"]
+      (g/collect ds) => [10 13 16 19])
+    (let [ds (g/range 0 100 1 5)]
+      (g/column-names ds) => ["id"]
+      (g/collect ds) => (range 100)
+      (count (g/partitions ds)) => 5)))

--- a/test/zero_one/geni/dataset_creation_test.clj
+++ b/test/zero_one/geni/dataset_creation_test.clj
@@ -2,7 +2,8 @@
   (:require
     [clojure.string :refer [includes?]]
     [midje.sweet :refer [facts fact =>]]
-    [zero-one.geni.core :as g])
+    [zero-one.geni.core :as g]
+    [zero-one.geni.test-resources :as tr])
   (:import
     (org.apache.spark.sql Dataset
                           Row)
@@ -13,19 +14,20 @@
 
 (facts "On creation of empty dataset" :empty-dataset
   (fact "correct creation"
-    (g/create-dataframe [] {}) => g/empty?
-    (g/table->dataset [] []) => g/empty?
-    (g/map->dataset {}) => g/empty?
-    (g/records->dataset {}) => g/empty?)
+    (g/create-dataframe @tr/spark [] {}) => g/empty?
+    (g/table->dataset @tr/spark [] []) => g/empty?
+    (g/map->dataset @tr/spark {}) => g/empty?
+    (g/records->dataset @tr/spark {}) => g/empty?)
   (fact "correct schema"
-    (g/dtypes (g/create-dataframe [] {:i :int})) => {:i "IntegerType"}
+    (g/dtypes (g/create-dataframe @tr/spark [] {:i :int})) => {:i "IntegerType"}
     (g/dtypes
-      (g/create-dataframe [] (g/struct-type (g/struct-field :j :float true))))
+      (g/create-dataframe @tr/spark [] (g/struct-type (g/struct-field :j :float true))))
     => {:j "FloatType"}))
 
 (fact "can instantiate dataframe with data-oriented schema" :schema
   (g/dtypes
     (g/create-dataframe
+      @tr/spark
       [(g/row 32 "horse" (g/dense 1.0 2.0) (g/sparse 4 [1 3] [3.0 4.0]))
        (g/row 64 "mouse" (g/dense 3.0 4.0) (g/sparse 4 [0 2] [1.0 2.0]))]
       {:number :int
@@ -49,6 +51,7 @@
       (g/struct-type field) => #(instance? StructType %)))
   (fact "can instantiate dataframe"
     (g/create-dataframe
+      @tr/spark
       [(g/row 32 "horse" (g/dense 1.0 2.0) (g/sparse 4 [1 3] [3.0 4.0]))
        (g/row 64 "mouse" (g/dense 3.0 4.0) (g/sparse 4 [0 2] [1.0 2.0]))]
       (g/struct-type
@@ -61,10 +64,12 @@
     (let [expected-dtypes {:number "LongType" :word "StringType"}]
       (g/dtypes
         (g/to-df
+          @tr/spark
           [[8 "bat"] [64 "mouse"] [-27 "horse"]]
           [:number :word])) => expected-dtypes
       (g/dtypes
         (g/create-dataframe
+          @tr/spark
           [(g/row 8 "bat")
            (g/row 64 "mouse")
            (g/row -27 "horse")]
@@ -73,14 +78,17 @@
             (g/struct-field :word :string true)))) => expected-dtypes
       (g/dtypes
         (g/table->dataset
+          @tr/spark
           [[8 "bat"] [64 "mouse"] [-27 "horse"]]
           [:number :word])) => expected-dtypes
       (g/dtypes
         (g/map->dataset
+          @tr/spark
           {:number [8 64 -27]
            :word   ["bat" "mouse" "horse"]})) => expected-dtypes
       (g/dtypes
         (g/records->dataset
+          @tr/spark
           [{:number   8 :word "bat"}
            {:number  64 :word "mouse"}
            {:number -27 :word "horse"}])) => expected-dtypes)))
@@ -88,6 +96,7 @@
 (facts "On map->dataset"
   (fact "should create the right dataset"
     (let [dataset (g/map->dataset
+                    @tr/spark
                     {:a [1 4]
                      :b [2.0 5.0]
                      :c ["a" "b"]})]
@@ -96,15 +105,18 @@
       (g/collect-vals dataset) => [[1 2.0 "a"] [4 5.0 "b"]]))
   (fact "should create the right schema even with nils"
     (let [dataset (g/map->dataset
+                    @tr/spark
                     {:a [nil 4]
                      :b [2.0 5.0]})]
       (g/collect-vals dataset) => [[nil 2.0] [4 5.0]]))
   (fact "should create the right null column"
     (let [dataset (g/map->dataset
+                    @tr/spark
                     {:a [1 4]
                      :b [nil nil]})]
       (g/collect-vals dataset) => [[1 nil] [4 nil]]))
   (let [dataset (g/table->dataset
+                  @tr/spark
                    [[0.0 (g/dense 0.5 10.0)]
                     [0.0 (g/dense 1.5 20.0)]
                     [1.0 (g/dense 1.5 30.0)]
@@ -117,6 +129,7 @@
 (facts "On records->dataset"
   (fact "should create the right dataset"
     (let [dataset (g/records->dataset
+                    @tr/spark
                     [{:a 1 :b 2.0 :c "a"}
                      {:a 4 :b 5.0 :c "b"}])]
       (instance? Dataset dataset) => true
@@ -124,6 +137,7 @@
       (g/collect-vals dataset) => [[1 2.0 "a"] [4 5.0 "b"]]))
   (fact "should create the right dataset even with missing keys"
     (let [dataset (g/records->dataset
+                    @tr/spark
                     [{:a 1 :c "a"}
                      {:a 4 :b 5.0}])]
       (g/column-names dataset) => ["a" "c" "b"]
@@ -132,6 +146,7 @@
 (facts "On table->dataset"
   (fact "should create the right dataset"
     (let [dataset (g/table->dataset
+                    @tr/spark
                     [[1 2.0 "a"]
                      [4 5.0 "b"]]
                     [:a :b :c])]

--- a/test/zero_one/geni/dataset_test.clj
+++ b/test/zero_one/geni/dataset_test.clj
@@ -13,12 +13,12 @@
                           SQLContext)))
 
 (fact "On to-df"
-  (let [dataframe (g/select df-1 :Suburb :Price)]
+  (let [dataframe (g/select (df-1) :Suburb :Price)]
     (g/collect (g/to-df dataframe)) => (g/collect dataframe)
     (g/columns (g/to-df dataframe [:suburb :price])) => [:suburb :price]))
 
 (fact "On Dataset hints" :slow
-  (-> df-1
+  (-> (df-1)
       (g/hint "myHint" 100 true)
       .queryExecution
       .logical
@@ -26,33 +26,34 @@
 
 (fact "On clojure idioms"
   (let [r-50      (range 50)
-        dataframe (g/records->dataset spark (map (fn [i] {:x i}) r-50))]
+        dataframe (g/records->dataset @spark (map (fn [i] {:x i}) r-50))]
     (-> dataframe (g/collect-col :x)) => r-50
     (-> dataframe g/shuffle (g/collect-col :x)) => #(and (not= % r-50)
                                                          (= (set %) (set r-50)))))
 
 (fact "On join-with"
-  (let [n-listings (-> df-50 (g/group-by :SellerG) g/count)]
-    (-> df-50
+  (let [base (df-50)
+        n-listings (-> (df-50) (g/group-by :SellerG) g/count)]
+    (-> base
         (g/join-with
           n-listings
           (g/=== (g/col n-listings :SellerG)
-                 (g/col-regex df-50 :SellerG)))
+                 (g/col-regex base :SellerG)))
         g/columns) => [:_1 :_2]
-    (-> df-50
+    (-> base
         (g/join-with
           n-listings
           (g/=== (g/col n-listings :SellerG)
-                 (g/col df-50 :SellerG))
+                 (g/col base :SellerG))
           "left")
         g/columns) => [:_1 :_2]))
 
 (facts "On non-group-by aggregations"
   (fact "On cube"
-    (-> df-20 (g/cube :SellerG :Suburb) g/count g/count) => 14
-    (-> df-20 (g/rollup :SellerG :Suburb) g/count g/count) => 13)
+    (-> (df-20) (g/cube :SellerG :Suburb) g/count g/count) => 14
+    (-> (df-20) (g/rollup :SellerG :Suburb) g/count g/count) => 13)
   (fact "On grouping"
-    (-> df-20
+    (-> (df-20)
         (g/cube :SellerG :Suburb)
         (g/agg (g/grouping :SellerG))
         g/collect-vals
@@ -60,25 +61,25 @@
         last) => 0))
 
 (fact "On alias"
-  (-> df-50 (g/alias :abc)) => (partial instance? Dataset))
+  (-> (df-50) (g/alias :abc)) => (partial instance? Dataset))
 
 (facts "On NA methods"
   (fact "On drop-na"
-    (-> df-50 g/drop-na g/count) => 34
-    (-> df-50 (g/drop-na 20) g/count) => 39
-    (-> df-50 (g/drop-na [:BuildingArea]) g/count) => 38
-    (-> df-50 (g/drop-na 1 [:BuildingArea]) g/count) => 38)
+    (-> (df-50) g/drop-na g/count) => 34
+    (-> (df-50) (g/drop-na 20) g/count) => 39
+    (-> (df-50) (g/drop-na [:BuildingArea]) g/count) => 38
+    (-> (df-50) (g/drop-na 1 [:BuildingArea]) g/count) => 38)
   (fact "On fill-na"
-    (-> df-50 (g/fill-na -999.0) (g/collect-col :BuildingArea) set)
+    (-> (df-50) (g/fill-na -999.0) (g/collect-col :BuildingArea) set)
     => #(% -999.0)
-    (-> df-50 (g/fill-na -999.0 [:Regionname]) (g/collect-col :BuildingArea) set)
+    (-> (df-50) (g/fill-na -999.0 [:Regionname]) (g/collect-col :BuildingArea) set)
     => #(nil? (% -999.0)))
   (fact "On replace"
-    (-> df-50 (g/replace-na :Rooms {1 -999}) (g/collect-col :Rooms) set)
+    (-> (df-50) (g/replace-na :Rooms {1 -999}) (g/collect-col :Rooms) set)
     => #(% -999)))
 
 (fact "On agg methods" :slow
-  (let [grouped (-> df-50 (g/group-by :SellerG))]
+  (let [grouped (-> (df-50) (g/group-by :SellerG))]
     (-> grouped (g/mean :Price :Rooms) g/column-names)
     => ["SellerG" "avg(Price)" "avg(Rooms)"]
     (-> grouped (g/min :Price :Rooms) g/column-names)
@@ -90,7 +91,7 @@
     (-> grouped g/count g/column-names) => ["SellerG" "count"]))
 
 (facts "On stats functions" :slow
-  (-> df-20
+  (-> (df-20)
       (g/select {:seller :SellerG :rooms :Rooms})
       g/distinct
       (g/limit 5)
@@ -99,7 +100,7 @@
                    36)
       g/collect) => [{:rooms 2 :seller "Biggin"} {:rooms 2 :seller "Jellis"}]
   (fact "On count-min-sketch"
-    (let [count-min (g/count-min-sketch melbourne-df :Suburb 10 10 10)]
+    (let [count-min (g/count-min-sketch (melbourne-df) :Suburb 10 10 10)]
       (g/add count-min "abc") => nil?
       (g/add count-min "abc" 10) => nil?
       (g/confidence count-min) => #(< 0.9 %)
@@ -110,12 +111,12 @@
       (g/total-count count-min) => #(< 10000 %)
       (g/width count-min) => 10))
   (fact "On cov"
-    (g/cov melbourne-df :Price :Rooms) => #(< 290000 % 310000))
+    (g/cov (melbourne-df) :Price :Rooms) => #(< 290000 % 310000))
   (fact "On corr"
-    (g/corr melbourne-df :Price :Rooms) => #(< 0.45 % 0.55)
-    (g/corr melbourne-df :Price :Rooms "pearson") => #(< 0.45 % 0.55))
+    (g/corr (melbourne-df) :Price :Rooms) => #(< 0.45 % 0.55)
+    (g/corr (melbourne-df) :Price :Rooms "pearson") => #(< 0.45 % 0.55))
   (fact "On cross-tab"
-    (-> df-20
+    (-> (df-20)
         (g/crosstab :Suburb :SellerG)
         g/collect) => [{:Biggin 9
                         :Collins 1
@@ -125,7 +126,7 @@
                         :Nelson 4
                         :Suburb_SellerG "Abbotsford"}])
   (fact "On freq-items"
-    (-> df-20
+    (-> (df-20)
         (g/freq-items [:Suburb :SellerG])
         g/collect) => [{:SellerG_freqItems ["LITTLE"
                                             "Biggin"
@@ -134,12 +135,12 @@
                                             "Greg"
                                             "Jellis"]
                         :Suburb_freqItems ["Abbotsford"]}]
-    (-> df-20
+    (-> (df-20)
         (g/freq-items [:Suburb :SellerG] 0.5)
         g/collect) => [{:SellerG_freqItems ["Biggin" "Collins"]
                         :Suburb_freqItems ["Abbotsford"]}])
   (fact "On bloom-filter"
-    (let [bloom (-> melbourne-df (g/bloom-filter :Suburb 10 0.01))]
+    (let [bloom (-> (melbourne-df) (g/bloom-filter :Suburb 10 0.01))]
       (g/bit-size bloom) => 128
       (g/compatible? bloom bloom) => true
       (g/expected-fpp bloom) => 1.0
@@ -147,24 +148,24 @@
       (g/might-contain bloom "Reservoir") => boolean?
       (g/put bloom "xyz") => boolean?))
   (fact "On approx-quantile"
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/approx-quantile :Price [0.1 0.9] 0.2)) => #(< (first %) (second %))
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/approx-quantile [:Price] [0.1 0.9] 0.2))
     => #(< (ffirst %) (second (first %)))))
 
 (fact "On random-split" :slow
-  (let [[train-df val-df] (-> df-50 (g/random-split [90 10]))]
+  (let [[train-df val-df] (-> (df-50) (g/random-split [90 10]))]
     (< (g/count val-df)
        (g/count train-df)) => true)
-  (let [[train-df val-df] (-> df-50 (g/random-split [90 10] 123))]
+  (let [[train-df val-df] (-> (df-50) (g/random-split [90 10] 123))]
     (< (g/count val-df)
        (g/count train-df)) => true))
 
 (facts "On printing functions"
   (fact "should return nil"
     (let [n-lines   #(-> % clojure.string/split-lines count)
-          df        (g/select melbourne-df :Suburb :Address)
+          df        (g/select (melbourne-df) :Suburb :Address)
           n-columns (-> df g/column-names count)]
       (n-lines (with-out-str (g/show (g/limit df 3)))) => 7
       (n-lines (with-out-str (g/show df {:num-rows 3 :vertical true}))) => 10
@@ -175,34 +176,34 @@
       (n-lines (interop/with-scala-out-str (g/explain df true))) => #(< 10 %))))
 
 (fact "On dtypes"
-  (-> melbourne-df g/dtypes :Suburb) => "StringType")
+  (-> (melbourne-df) g/dtypes :Suburb) => "StringType")
 
 (fact "On local"
-  (-> melbourne-df g/local?) => boolean?)
+  (-> (melbourne-df) g/local?) => boolean?)
 
 (fact "On ungrouped methods"
-  (-> melbourne-df g/streaming?) => false
-  (-> melbourne-df g/spark-session) => (partial instance? SparkSession)
-  (-> melbourne-df g/sql-context) => (partial instance? SQLContext)
-  (-> df-1 g/to-json g/collect) => (every-pred seq? #(every? string? %))
-  (-> df-1 g/to-string) => string?
-  (-> df-20
+  (-> (melbourne-df) g/streaming?) => false
+  (-> (melbourne-df) g/spark-session) => (partial instance? SparkSession)
+  (-> (melbourne-df) g/sql-context) => (partial instance? SQLContext)
+  (-> (df-1) g/to-json g/collect) => (every-pred seq? #(every? string? %))
+  (-> (df-1) g/to-string) => string?
+  (-> (df-20)
       (g/limit 2)
       (g/select :Date :CouncilArea)
       g/to-json
       g/collect) => ["{\"Date\":\"3/12/2016\",\"CouncilArea\":\"Yarra\"}"
                      "{\"Date\":\"4/02/2016\",\"CouncilArea\":\"Yarra\"}"]
-  (-> df-1 g/to-json g/collect) => (-> df-1 g/to-json g/collect))
+  (-> (df-1) g/to-json g/collect) => (-> (df-1) g/to-json g/collect))
 
 (facts "On pivot" :slow
   (fact "pivot should return the expected cols"
-    (let [pivotted (-> df-20
+    (let [pivotted (-> (df-20)
                        (g/group-by :SellerG)
                        (g/pivot :Method)
                        (g/agg (-> (g/count "*") (g/as "n"))))]
       (-> pivotted g/column-names set) => #{"SellerG" "PI" "S" "SP" "VB"}))
   (fact "pivot should be able to specify pivot columns"
-    (let [pivotted (-> df-20
+    (let [pivotted (-> (df-20)
                        (g/group-by :SellerG)
                        (g/pivot :Method ["SP" "VB" "XYZ"])
                        (g/agg (-> (g/count "*") (g/as "n"))))]
@@ -210,7 +211,7 @@
 
 (facts "On when"
   (fact "when null and coalesce should be equivalent"
-    (-> df-20
+    (-> (df-20)
         (g/with-column "x"
           (g/when (g/null? :BuildingArea) -999 :BuildingArea))
         (g/with-column "y"
@@ -221,29 +222,29 @@
 
 (facts "On select"
   (fact "should drop unselected columns"
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/select :Type (g/col :Price) :Regionname {:a :SellerG :b :BuildingArea})
         g/column-names) => ["Type" "Price" "Regionname" "a" "b"])
   (fact "select-expr works as expected"
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/select-expr "Price+1" "Rooms-1")
         g/column-names) => ["(Price + 1)" "(Rooms - 1)"])
   (fact "column order should be preserved"
-    (-> melbourne-df
+    (-> (melbourne-df)
         (g/select (range 100))
         g/collect-vals
         first) => (range 100)))
 
 (facts "On filter"
-  (let [df (-> df-20 (g/select :SellerG))]
+  (let [df (-> (df-20) (g/select :SellerG))]
     (fact "should implicitly cast to boolean"
-      (-> df-20
+      (-> (df-20)
           (g/select :Rooms)
           (g/filter (g/- :Rooms 2))
           g/distinct
           (g/collect-col :Rooms)
           set) => #(not (% 2))
-      (-> df-20
+      (-> (df-20)
           (g/select :Rooms)
           (g/remove (g/- :Rooms 2))
           g/distinct
@@ -275,21 +276,21 @@
 
 (facts "On rename-columns"
   (fact "the new name should exist and the old name should not"
-    (let [col-names (-> melbourne-df
+    (let [col-names (-> (melbourne-df)
                         (g/rename-columns {:Regionname :region-name})
                         g/columns
                         set)]
       col-names => #(contains? % :region-name)
       col-names => #(not (contains? % :Regionname))))
   (fact "with-column-renamed actually renames column"
-    (-> df-1
+    (-> (df-1)
         (g/with-column-renamed :SellerG :seller)
         g/columns
         set) => #(nil? (% :SellerG))))
 
 (facts "On actions" :slow
   (fact "correct collection of lits"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/lit 1)
           (g/lit "a")
@@ -297,94 +298,94 @@
           (g/lit ["b"]))
         g/first-vals) => [1 "a" [2.0] ["b"]])
   (fact "action functions work"
-    (g/head df-20) => map?
-    (g/head df-20 2) => #(= (count %) 2)
-    (g/head-vals df-20) => vector?
-    (g/head-vals df-20 3) => #(and (= (count %) 3) (every? vector? %))
-    (g/take df-20 5) => #(and (= (count %) 5) (every? map? %))
-    (g/take-vals df-20 10) => #(and (= (count %) 10) (every? vector? %))
-    (g/tail df-20 5) => #(and (= (count %) 5) (every? map? %))
-    (g/tail-vals df-20 10) => #(and (= (count %) 10) (every? vector? %)))
+    (g/head (df-20)) => map?
+    (g/head (df-20) 2) => #(= (count %) 2)
+    (g/head-vals (df-20)) => vector?
+    (g/head-vals (df-20) 3) => #(and (= (count %) 3) (every? vector? %))
+    (g/take (df-20) 5) => #(and (= (count %) 5) (every? map? %))
+    (g/take-vals (df-20) 10) => #(and (= (count %) 10) (every? vector? %))
+    (g/tail (df-20) 5) => #(and (= (count %) 5) (every? map? %))
+    (g/tail-vals (df-20) 10) => #(and (= (count %) 10) (every? vector? %)))
   (fact "first works"
-    (-> df-20 (g/select :Address) g/first) => {:Address "85 Turner St"}
-    (-> df-20 (g/select :Address) g/first-vals) => ["85 Turner St"]
-    (-> df-20 (g/select :Address) g/last) => {:Address "42 Valiant St"}
-    (-> df-20 (g/select :Address) g/last-vals) => ["42 Valiant St"]))
+    (-> (df-20) (g/select :Address) g/first) => {:Address "85 Turner St"}
+    (-> (df-20) (g/select :Address) g/first-vals) => ["85 Turner St"]
+    (-> (df-20) (g/select :Address) g/last) => {:Address "42 Valiant St"}
+    (-> (df-20) (g/select :Address) g/last-vals) => ["42 Valiant St"]))
 
 (facts "On drop" :slow
   (fact "dropped columns should no longer exist"
-    (let [original-columns (-> melbourne-df g/columns set)
+    (let [original-columns (-> (melbourne-df) g/columns set)
           columns-to-drop  #{:Suburb :Price :YearBuilt}
-          dropped-columns  (-> melbourne-df
+          dropped-columns  (-> (melbourne-df)
                                (g/drop columns-to-drop)
                                g/columns
                                set)]
       (clojure.set/subset? columns-to-drop original-columns) => true
       (clojure.set/intersection columns-to-drop dropped-columns) => empty?))
   (fact "drop duplicates without arg should not drop everything"
-    (-> df-20
+    (-> (df-20)
         (g/select :Method :SellerG)
         g/drop-duplicates
         g/count) => 10)
   (fact "drop duplicates can be called with columns"
-    (-> df-20
+    (-> (df-20)
         (g/select :Method :SellerG)
         (g/drop-duplicates :SellerG)
         g/count) => 6))
 
 (facts "On except and intercept" :slow
   (fact "except should exclude the row"
-    (-> df-20
-        (g/union df-20)
-        (g/except df-1)
+    (-> (df-20)
+        (g/union (df-20))
+        (g/except (df-1))
         g/count) => 19)
   (fact "except all should leave out the duplicates"
-    (-> df-20
-        (g/union df-20)
-        (g/except-all df-1)
+    (-> (df-20)
+        (g/union (df-20))
+        (g/except-all (df-1))
         g/count) => 39)
   (fact "except then intercept should be empty"
-    (-> df-20
-        (g/except df-1)
-        (g/intersect df-1)
+    (-> (df-20)
+        (g/except (df-1))
+        (g/intersect (df-1))
         g/empty?) => true)
   (fact "intersect all should preserve duplicates"
-    (-> df-20
-        (g/union df-20)
-        (g/intersect-all df-1)
+    (-> (df-20)
+        (g/union (df-20))
+        (g/intersect-all (df-1))
         g/count) => 1)) ; TODO: this should be 2
 
 (facts "On union" :slow
   (fact "Union should double the rows preserve distinctness"
-    (let [unioned (g/union df-20 df-20 df-20)]
+    (let [unioned (g/union (df-20) (df-20) (df-20))]
       (g/count unioned) => 60
       (-> unioned g/distinct g/count) => 20))
   (fact "Union by name should line up the names"
-    (let [left (-> df-1 (g/select :Suburb :SellerG))
-          right (-> df-1 (g/select :SellerG :Suburb))]
+    (let [left (-> (df-1) (g/select :Suburb :SellerG))
+          right (-> (df-1) (g/select :SellerG :Suburb))]
       (-> left (g/union-by-name right right) g/distinct g/count)) => 1))
 
 (facts "On describe" :slow
   (fact "describe should have the right shape"
-    (let [summary (-> df-20 (g/describe :Price))]
+    (let [summary (-> (df-20) (g/describe :Price))]
       (g/column-names summary) => ["summary" "Price"]
       (map :summary (g/collect summary)) => ["count" "mean" "stddev" "min" "max"]))
   (fact "summary should only pick some stats"
-    (-> df-20
+    (-> (df-20)
         (g/select :Rooms)
         (g/summary "count" "min")
         g/collect-vals) => [["count" "20"] ["min" "1"]]))
 
 (facts "On sample" :slow
-  (let [with-rep    (g/sample df-50 0.8 true)
-        without-rep (g/sample df-50 0.8)]
+  (let [with-rep    (g/sample (df-50) 0.8 true)
+        without-rep (g/sample (df-50) 0.8)]
     (fact "Sampling without replacement should have all unique rows"
       (-> without-rep g/distinct g/count) => (g/count without-rep))
     (fact "Sampling with replacement should have less unique rows"
       (-> with-rep g/distinct g/count) => #(< % 40))))
 
 (facts "On order-by" :slow
-  (let [df (-> df-20 (g/select (g/as (g/->date-col :Date "d/MM/yyyy") :Date)))]
+  (let [df (-> (df-20) (g/select (g/as (g/->date-col :Date "d/MM/yyyy") :Date)))]
     (fact "should correctly order dates - desc"
       (let [records (-> df (g/order-by (g/desc :Date)) g/collect)
             dates   (map #(str (% :Date)) records)]
@@ -396,61 +397,61 @@
 
 (facts "On caching" :slow
   (fact "should keeps data in memory")
-  (let [df (-> df-1 g/cache)]
+  (let [df (-> (df-1) g/cache)]
     (.useMemory (g/storage-level df)) => true)
-  (let [df (-> df-1 g/persist)]
+  (let [df (-> (df-1) g/persist)]
     (.useMemory (g/storage-level df)) => true)
-  (let [df (-> df-1 g/persist)]
+  (let [df (-> (df-1) g/persist)]
     (.useMemory (g/storage-level df)) => true)
-  (let [df (-> df-1 g/persist g/unpersist)]
+  (let [df (-> (df-1) g/persist g/unpersist)]
     (.useMemory (g/storage-level df)) => false)
-  (let [df (-> df-1 g/persist (g/unpersist true))]
+  (let [df (-> (df-1) g/persist (g/unpersist true))]
     (.useMemory (g/storage-level df)) => false)
-  (let [df (g/persist df-1 g/memory-only-ser-2)]
+  (let [df (g/persist (df-1) g/memory-only-ser-2)]
     (g/storage-level df)) => g/memory-only-ser-2
-  (g/input-files melbourne-df) => nil?
-  (g/rdd melbourne-df) => #(instance? RDD %)
+  (g/input-files (melbourne-df)) => seq?
+  (g/rdd (melbourne-df)) => #(instance? RDD %)
   (let [checkpointed? (fn [df] (-> df
                                    .queryExecution
                                    .toRdd
                                    .toDebugString
                                    (clojure.string/includes? "CheckpointRDD")))]
-    df-1 => (complement checkpointed?)
-    (g/checkpoint df-1) => checkpointed?
-    (g/checkpoint df-1 true) => checkpointed?))
+    (df-1) => (complement checkpointed?)
+    (g/checkpoint (df-1)) => checkpointed?
+    (g/checkpoint (df-1) true) => checkpointed?))
 
 (facts "On repartition" :slow
   (fact "able to repartition by a number"
-    (-> df-20
+    (-> (df-20)
         (g/repartition 2)
         g/partitions
         count) => 2)
   (fact "able to repartition by columns"
-    (-> df-20
+    (-> (df-20)
         (g/repartition :Suburb :SellerG)
         g/partitions
         count) => #(< 1 %))
   (fact "able to repartition by number and columns"
-    (-> df-20
+    (-> (df-20)
         (g/repartition 10 :Suburb :SellerG)
         g/partitions
         count) => 10)
   (fact "able to repartition by range by columns"
-    (-> df-20
+    (-> (df-20)
         (g/repartition-by-range :Suburb :SellerG)
         g/partitions
         count) => 7)
   (fact "able to repartition by range by number and columns"
-    (-> df-20
+    (-> (df-20)
         (g/repartition-by-range 3 :Suburb :SellerG)
         g/partitions
         count) => 3)
   (fact "sort within partitions is differnt to sort"
-    (let [sorted  (-> df-20
+    (let [sorted  (-> (df-20)
                       (g/select :Method :SellerG)
                       (g/order-by :Method)
                       g/collect-vals)
-          sorted-within (-> df-20
+          sorted-within (-> (df-20)
                             (g/select :Method :SellerG)
                             (g/repartition 2 :SellerG)
                             (g/sort-within-partitions :Method)
@@ -458,7 +459,7 @@
       (= sorted sorted-within) => false
       (set sorted) => (set sorted-within)))
   (fact "coalesce should reduce the number of partitions"
-    (-> df-20
+    (-> (df-20)
         (g/repartition 5)
         (g/coalesce 2)
         g/partitions
@@ -466,63 +467,65 @@
 
 (facts "On join" :slow
   (fact "joining with join exprs"
-    (-> df-50
-        (g/join df-1
-                (g/= (g/col df-50 :Suburb)
-                     (g/col df-1 :Suburb))
-                "inner")
-        g/count) => 38)
+    (let [left (df-1)
+          right (df-50)]
+      (-> left
+          (g/join right
+                  (g/= (g/col right :Suburb)
+                       (g/col left :Suburb))
+                 "inner")
+        g/count) => 38))
   (fact "normal join works as expected"
-    (let [grouped (-> df-50
+    (let [grouped (-> (df-50)
                       (g/group-by :SellerG :Regionname)
                       (g/agg {:mean-price (g/mean :Price)}))]
-      (-> df-50 (g/join grouped [:SellerG :Regionname]) g/columns set)
+      (-> (df-50) (g/join grouped [:SellerG :Regionname]) g/columns set)
       => #(contains? % :mean-price)))
   (fact "normal join works as expected"
-    (let [n-listings (-> df-50
+    (let [n-listings (-> (df-50)
                          (g/group-by :Suburb)
                          (g/agg (g/as (g/count "*") :n-listings)))]
-      (-> df-50 (g/join n-listings :Suburb) g/columns set)
+      (-> (df-50) (g/join n-listings :Suburb) g/columns set)
       => #(contains? % :n-listings)
-      (-> df-50 (g/join n-listings :Suburb "inner") g/columns set)
+      (-> (df-50) (g/join n-listings :Suburb "inner") g/columns set)
       => #(contains? % :n-listings)
-      (-> df-50 (g/join n-listings [:Suburb] "inner") g/columns set)
+      (-> (df-50) (g/join n-listings [:Suburb] "inner") g/columns set)
       => #(contains? % :n-listings)))
   (fact "cross-join works as expected"
-    (-> df-20
+    (-> (df-20)
         (g/select :Suburb)
-        (g/cross-join (-> df-20 (g/select :Method)))
+        (g/cross-join (-> (df-20) (g/select :Method)))
         g/count) => 400))
 
 (facts "On group-by and agg" :slow
   (fact "group-by with map"
-    (-> df-20
+    (-> (df-20)
         (g/group-by {:seller :SellerG :rooms :Rooms})
         (g/agg {:mean-price (g/mean :Price)})
         g/columns) => [:seller :rooms :mean-price])
   (fact "group-by with map"
-    (-> df-20
+    (-> (df-20)
         (g/group-by :SellerG)
         (g/agg {:n-regions (g/count-distinct :Regionname)
                 :n-null-building-area (g/null-count :BuildingArea)})
         g/column-names) => ["SellerG" "n-regions" "n-null-building-area"])
   (fact "should have the right shape"
-    (let [agged (-> df-50
+    (let [agged (-> (df-50)
                     (g/group-by :Type)
                     (g/agg
                       (-> (g/count "*") (g/as "n_rows"))
                       (-> (g/max :Price) (g/as "max_price"))))]
-      (g/count agged) => (-> df-50 (g/select :Type) g/distinct g/count)
+      (g/count agged) => (-> (df-50) (g/select :Type) g/distinct g/count)
       (g/column-names agged) => ["Type" "n_rows" "max_price"]))
   (fact "agg-all should apply to all columns"
-    (-> df-20
+    (-> (df-20)
         (g/select :Price :Regionname :Car)
         (g/agg-all g/count-distinct)
         g/collect
         first
         count) => 3)
   (fact "works with nested data structure"
-    (let [agged    (-> df-20
+    (let [agged    (-> (df-20)
                        (g/group-by :SellerG)
                        (g/agg
                          (-> (g/collect-list :Suburb) (g/as "suburbs_list"))

--- a/test/zero_one/geni/main_test.clj
+++ b/test/zero_one/geni/main_test.clj
@@ -16,7 +16,7 @@
     (repl/geni-prompt "xyz") => "geni-repl (xyz)\nλ ")
 
   (fact "correct welcome note"
-    (repl/spark-welcome-note (.version spark))
+    (repl/spark-welcome-note (.version @spark))
     => #(clojure.string/includes? % "spark"))
 
   (fact "correct nREPL connection"

--- a/test/zero_one/geni/ml_frequent_pattern_test.clj
+++ b/test/zero_one/geni/ml_frequent_pattern_test.clj
@@ -7,7 +7,7 @@
 
 (facts "On Prefix-Span training" :slow
   (let [dataset     (-> (g/table->dataset
-                          spark
+                          @spark
                           [[['(1 2) '(3)]]
                            [['(1) '(3 2) '(1 2)]]
                            [['(1 2) '(5)]]]
@@ -22,7 +22,7 @@
 
 (facts "On FP-Growth training" :slow
  (let [dataset   (-> (g/table->dataset
-                      spark
+                      @spark
                        [[["1" "2" "5"]]
                         [["1" "2" "3" "5"]]
                         [["1" "2"]]]

--- a/test/zero_one/geni/ml_recommendation_test.clj
+++ b/test/zero_one/geni/ml_recommendation_test.clj
@@ -11,16 +11,16 @@
                              :user-col   :user-id
                              :item-col   :movie-id
                              :rating-col :rating})
-        model       (ml/fit ratings-df estimator)
+        model       (ml/fit (ratings-df) estimator)
         predictions (do
                       (.setColdStartStrategy model "drop")
-                      (ml/transform ratings-df model))
+                      (ml/transform (ratings-df) model))
         evaluator   (ml/regression-evaluator {:metric-name    "rmse"
                                               :label-col      :rating
                                               :prediction-col :prediction})
         rmse        (ml/evaluate predictions evaluator)
-        some-users  (-> ratings-df (g/select :user-id) g/distinct (g/limit 3))
-        some-items  (-> ratings-df (g/select :movie-id) g/distinct (g/limit 5))]
+        some-users  (-> (ratings-df) (g/select :user-id) g/distinct (g/limit 3))
+        some-items  (-> (ratings-df) (g/select :movie-id) g/distinct (g/limit 5))]
     rmse => #(<= % 0.9)
     (g/count (ml/item-factors model)) => 100
     (g/count (ml/user-factors model)) => 30

--- a/test/zero_one/geni/ml_tuning_test.clj
+++ b/test/zero_one/geni/ml_tuning_test.clj
@@ -37,7 +37,7 @@
                         :estimator-param-maps param-grid
                         :evaluator (ml/binary-classification-evaluator {})
                         :num-folds 2})
-          model      (ml/fit libsvm-df cv)]
+          model      (ml/fit (libsvm-df) cv)]
       (ml/best-model model) => (partial instance? LogisticRegressionModel))))
 
 (facts "On cross validator"

--- a/test/zero_one/geni/numpy_test.clj
+++ b/test/zero_one/geni/numpy_test.clj
@@ -2,10 +2,10 @@
   (:require
     [midje.sweet :refer [throws fact =>]]
     [zero-one.geni.core :as g]
-    [zero-one.geni.test-resources :refer [df-20]]))
+    [zero-one.geni.test-resources :refer [spark df-20]]))
 
 (defn descriptive-stats [col]
-  (-> (g/table->dataset (mapv vector (range 200)) [:idx])
+  (-> (g/table->dataset @spark (mapv vector (range 200)) [:idx])
       (g/with-column :x col)
       (g/agg {:min  (g/min :x)
               :mean (g/mean :x)
@@ -50,13 +50,13 @@
                                                             (double? (:min %))))
 
 (fact "On random-choice" :slow
-  (-> (g/table->dataset (mapv vector (range 100)) [:idx])
+  (-> (g/table->dataset @spark (mapv vector (range 100)) [:idx])
       (g/with-column :rand-choice (g/random-choice [(g/lit "abc")
                                                     (g/lit "def")
                                                     (g/lit "ghi")]))
       (g/collect-col :rand-choice)
       set) => #{"abc" "def" "ghi"}
-  (-> (g/table->dataset (mapv vector (range 2000)) [:idx])
+  (-> (g/table->dataset @spark (mapv vector (range 2000)) [:idx])
       (g/with-column :rand-choice (g/random-choice [0 1 2 3] [0.5 0.3 0.15 0.05]))
       (g/select :rand-choice)
       g/value-counts
@@ -66,7 +66,7 @@
   (g/random-choice [0 1] [-1.0 2.0]) => (throws AssertionError))
 
 (fact "On clip" :slow
-  (-> df-20
+  (-> (df-20)
       (g/select (g/clip :Price 9e5 1.1e6))
       g/collect-vals
       flatten) => (fn [xs] (every? #(<= 9e5 % 1.1e6) xs)))

--- a/test/zero_one/geni/pandas_test.clj
+++ b/test/zero_one/geni/pandas_test.clj
@@ -5,7 +5,7 @@
     [zero-one.geni.test-resources :refer [df-20]]))
 
 (fact "On cut" :slow
-  (-> df-20
+  (-> (df-20)
       (g/with-column :cut (g/cut :Price [1e6]))
       (g/collect-col :cut)
       set) => #{"Price[-Infinity, 1000000.0]"
@@ -13,14 +13,14 @@
   (g/cut :Price [1.1e6 1e6]) => (throws AssertionError))
 
 (fact "On qcut" :slow
-  (-> df-20
+  (-> (df-20)
       (g/with-column :qcut (g/qcut :Price 4))
       (g/collect-col :qcut)
       set) => #{"Price[0.0, 0.25]"
                 "Price[0.25, 0.5]"
                 "Price[0.5, 0.75]"
                 "Price[0.75, 1.0]"}
-  (-> df-20
+  (-> (df-20)
       (g/with-column :qcut (g/qcut :Price [0.1 0.9]))
       (g/collect-col :qcut)
       set) => #{"Price[0.0, 0.1]"
@@ -30,20 +30,20 @@
   (g/qcut :Price [0.8 1.2]) => (throws AssertionError))
 
 (fact "On interquartile range" :slow
-  (-> df-20
+  (-> (df-20)
       (g/limit 5)
       (g/group-by :SellerG)
       (g/agg (g/iqr :Price))
       g/collect) => [{:SellerG "Biggin" (keyword "iqr(Price)") 615000.0}
                      {:SellerG "Nelson" (keyword "iqr(Price)") 0.0}]
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Price :Rooms)
       (g/group-by :SellerG)
       (g/iqr :Price :Rooms)
       g/dtypes) => {:SellerG "StringType"
                     (keyword "iqr(Price)") "DoubleType"
                     (keyword "iqr(Rooms)") "LongType"}
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Price :Rooms)
       (g/group-by :SellerG)
       (g/iqr [:Price :Rooms])
@@ -52,25 +52,25 @@
                     (keyword "iqr(Rooms)") "LongType"})
 
 (fact "On quantile and median" :slow
-  (-> df-20
+  (-> (df-20)
       (g/group-by :SellerG)
       (g/agg (g/quantile :Price 0.25))
       g/dtypes) => {:SellerG "StringType"
                     (keyword "quantile(Price, 0.25)") "DoubleType"}
-  (-> df-20
+  (-> (df-20)
       (g/group-by :SellerG)
       (g/agg (g/quantile :Price [0.25 0.75]))
       g/dtypes) => {:SellerG "StringType"
                     (keyword "quantile(Price, array(0.25, 0.75))")
                     "ArrayType(DoubleType,false)"}
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Price :Rooms)
       (g/group-by :SellerG)
       (g/quantile [0.25 0.75] [:Price :Rooms])
       g/column-names) => ["SellerG"
                           "quantile(Price, array(0.25, 0.75))"
                           "quantile(Rooms, array(0.25, 0.75))"]
-  (-> df-20
+  (-> (df-20)
       (g/group-by :SellerG)
       (g/agg (g/median :Price))
       g/collect) => [{:SellerG "Biggin"  (keyword "median(Price)") 1035000.0}
@@ -79,26 +79,26 @@
                      {:SellerG "Greg"    (keyword "median(Price)") 441000.0}
                      {:SellerG "LITTLE"  (keyword "median(Price)") 1176500.0}
                      {:SellerG "Collins" (keyword "median(Price)") 955000.0}]
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Price :Rooms)
       (g/group-by :SellerG)
       (g/median :Price :Rooms)
       g/column-names) => ["SellerG" "median(Price)" "median(Rooms)"])
 
 (fact "On nlargest, nsmallest and nunique" :slow
-  (-> df-20
+  (-> (df-20)
       (g/nlargest 3 :Price)
       (g/collect-col :Price)) => [1876000.0 1636000.0 1600000.0]
-  (-> df-20
+  (-> (df-20)
       (g/nsmallest 3 :Price)
       (g/collect-col :Price)) => [300000.0 441000.0 700000.0]
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Suburb)
       g/nunique
       g/first) => {(keyword "count(SellerG)") 6 (keyword "count(Suburb)")  1})
 
 (fact "On value-counts" :slow
-  (-> df-20
+  (-> (df-20)
       (g/select :SellerG :Suburb)
       g/value-counts
       (g/order-by (g/desc :count) :SellerG :Suburb)
@@ -110,4 +110,4 @@
                      {:SellerG "LITTLE"  :Suburb "Abbotsford" :count 1}])
 
 (fact "On shape"
-  (g/shape df-20) => [20 21])
+  (g/shape (df-20)) => [20 21])

--- a/test/zero_one/geni/spark_setup_test.clj
+++ b/test/zero_one/geni/spark_setup_test.clj
@@ -9,15 +9,15 @@
     (org.apache.spark.sql Dataset SparkSession)))
 
 (fact "Test spark session and dataframe"
-  spark => #(instance? SparkSession %)
-  melbourne-df => #(instance? Dataset %)
-  (-> spark .conf .getAll interop/scala-map->map)
+  @spark => #(instance? SparkSession %)
+  (melbourne-df) => #(instance? Dataset %)
+  (-> @spark .conf .getAll interop/scala-map->map)
   => #(= (% "spark.master") "local[*]")
-  (-> spark .sparkContext .getCheckpointDir .get)
+  (-> @spark .sparkContext .getCheckpointDir .get)
   => #(clojure.string/includes? % "target/checkpoint/")
-  (-> spark .sparkContext .getConf g/to-debug-string)
+  (-> @spark .sparkContext .getConf g/to-debug-string)
   => #(clojure.string/includes? % "spark.app.id")
-  (select-keys (g/spark-conf spark) [:spark.master
+  (select-keys (g/spark-conf @spark) [:spark.master
                                      :spark.app.name
                                      :spark.testing.memory
                                      :spark.sql.adaptive.enabled
@@ -29,7 +29,7 @@
 
 
 (fact "Test primary key is the product of address, date and seller"
-  (-> melbourne-df
+  (-> (melbourne-df)
       (g/with-column
         "entry_id"
         (g/concat "Address" (g/lit "::") "Date" (g/lit "::") "SellerG"))

--- a/test/zero_one/geni/sql_functions_test.clj
+++ b/test/zero_one/geni/sql_functions_test.clj
@@ -12,7 +12,7 @@
     (java.time.format DateTimeFormatter)))
 
 (facts "On JSON functions"
-  (-> df-1
+  (-> (df-1)
       (g/select
         {:schema-1 (g/schema-of-json (g/lit "[{\"col\":0}]"))
          :schema-2 (g/schema-of-json (g/lit "[{\"col\":01}]") {:allowNumericLeadingZeros "true"})
@@ -32,7 +32,7 @@
                  :to-2 "{\"time\":\"26/08/2015\"}"})
 
 (facts "On CSV functions"
-  (-> df-1
+  (-> (df-1)
       (g/select
         {:schema-1 (g/schema-of-csv (g/lit "1,abc"))
          :schema-2 (g/schema-of-csv (g/lit "1|abc") {:delimiter "|"})
@@ -52,7 +52,7 @@
                  :to-2     "26/08/2015"})
 
 (facts "On map functions"
-  (-> df-20
+  (-> (df-20)
       (g/limit 1)
       (g/select
         {:location (g/map (g/lit "suburb") :Suburb
@@ -72,7 +72,7 @@
                        "address" "85 Turner St"},
                       :market {"size" 1480000.0, "price" 1480000.0},
                       :coord {"lat" -37.7996, "long" 144.9984}}]
-  (-> df-1
+  (-> (df-1)
       (g/with-column :location (g/struct
                                  {:address :Address
                                   :suburbs :Suburb
@@ -88,7 +88,7 @@
                                             :region "Northern Metropolitan"
                                             :suburbs "Abbotsford"}}
                       :seller "Biggin"}]
-  (-> df-1
+  (-> (df-1)
       (g/with-column
         :map
         (g/map-from-entries (g/array (g/struct 1 (g/lit "a"))
@@ -137,16 +137,16 @@
   (g/assoc :map 7 (g/lit "x") 3) => (throws IllegalArgumentException))
 
 (fact "On misc functions"
-  (-> df-1
+  (-> (df-1)
       (g/select (g/input-file-name))
       g/collect-vals) => [[""]]
-  (-> df-1
+  (-> (df-1)
       (g/select (g/crc32 (g/encode (g/lit "123") "UTF-8")))
       g/collect-vals
       ffirst) => int?)
 
 (fact "On number functions"
-  (-> df-1
+  (-> (df-1)
       (g/select
         (g/shift-right 2 1)
         (g/shift-left 2 1)
@@ -154,7 +154,7 @@
         (g/bitwise-not -123)
         (g/bround -123.456))
       g/collect-vals) => [[1 4 9223372036854775807 122 -123.0]]
-  (-> df-1
+  (-> (df-1)
       (g/select
         (g/rint 3.2)
         (g/log1p 0)
@@ -165,7 +165,7 @@
         (g/hypot 3 4)
         (g/base64 (g/unbase64 (g/lit "abc"))))
       g/collect-vals) => [[3.0 0.0 1.0 -1.0 3.0 [1] 5.0 "abc="]]
-  (-> df-1
+  (-> (df-1)
       (g/select
         (g/bin (g/lit "12"))
         (g/conv (g/lit "12") 10 3)
@@ -179,7 +179,7 @@
 
 (facts "On string functions" :slow
   (fact "correct ascii"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/ascii :Suburb)
           (g/length :Suburb)
@@ -194,14 +194,14 @@
         g/collect-vals
         first) => [65 10 19 4 "foobaz" "Abc" 3 "1122" "Ababcsford" "Abxyzotsford"])
   (fact "correct concat-ws"
-    (-> df-20
+    (-> (df-20)
         (g/group-by :Suburb)
         (g/agg (-> (g/collect-set :SellerG) (g/as :sellers)))
         (g/select (g/concat-ws "," :sellers))
         g/collect-vals
         ffirst) => "Biggin,Jellis,Collins,Nelson,Greg,LITTLE")
   (fact "correct substring"
-    (-> df-20
+    (-> (df-20)
         (g/select
           (g/substring :Suburb 3 4)
           (g/substring-index :Suburb "bb" 1)
@@ -211,23 +211,23 @@
         g/collect-vals) => [["bots" "A" "otsford" "A132"]]))
 
 (facts "On agg functions" :slow
-  (-> df-20
+  (-> (df-20)
       (g/cube :SellerG :Regionname)
       (g/agg (g/grouping-id :SellerG :Regionname))
       g/first-vals) => ["Biggin" "Northern Metropolitan" 0]
-  (-> df-20
+  (-> (df-20)
       (g/group-by :SellerG)
       (g/agg (-> (g/collect-list :Regionname) (g/as :regions)))
       (g/select (g/posexplode :regions))
       g/count) => 20
-  (-> df-20
+  (-> (df-20)
       (g/group-by :SellerG)
       (g/agg
         (g/first :Regionname)
         (g/last :Regionname))
       g/collect-vals
       first) => ["Biggin" "Northern Metropolitan" "Northern Metropolitan"]
-  (-> df-20
+  (-> (df-20)
       (g/select
         (g/corr :Price :Rooms)
         (g/covar :Price :Rooms)
@@ -239,26 +239,26 @@
       flatten) => #(and (= 6 (count %)) (double? (first %))))
 
 (facts "On hash"
-  (-> df-20
+  (-> (df-20)
       (g/select (g/hash :SellerG :Regionname))
       g/collect-vals
       flatten) => #(and (= 6 (count (distinct %)))
                         (= 20 (count %))))
 
 (facts "On expr"
-  (-> df-1
+  (-> (df-1)
       (g/select (g/expr "1"))
       g/collect-vals) => [[1]])
 
 (fact "On broadcast"
-  (-> melbourne-df g/broadcast) => #(instance? Dataset %))
+  (-> (melbourne-df) g/broadcast) => #(instance? Dataset %))
 
 (fact "On array functions" :slow
-  (-> df-20
+  (-> (df-20)
       (g/select
         (-> (g/monotonically-increasing-id) (g/as "id")))
       (g/collect-col "id")) => (range 20)
-  (-> df-1
+  (-> (df-1)
       (g/select
         {:struct (g/struct :SellerG :Rooms)
          :filtered-1 (g/filter (g/array 1 2 3) g/even?)
@@ -267,7 +267,7 @@
       first) => {:struct     {:SellerG "Biggin" :Rooms 2}
                  :filtered-1 [2]
                  :filtered-2 [-1 0 1]}
-  (-> df-1
+  (-> (df-1)
       (g/with-column "xs" (g/array [1 2 1]))
       (g/with-column "ys" (g/array [3 2 1]))
       (g/with-column "zs" (g/array [(g/lit "x") (g/lit "y")]))
@@ -286,7 +286,7 @@
         (g/forall :ys #(g/< % 10)))
       g/collect-vals
       first) => [[1 2 1] true [1 2] [3] [2 1] "x,y" "x,y" 2 4 16 false true]
-  (-> df-1
+  (-> (df-1)
       (g/with-column "ys" (g/array [-3 -2 -1]))
       (g/with-column "xs" (g/array [1 2 1]))
       (g/select
@@ -302,7 +302,7 @@
       first) => [[2] [1 1] [2 2 2] [1 1 2] true 2 [-2 0 0] [{:xs 1 :ys -3}
                                                             {:xs 2 :ys -2}
                                                             {:xs 1 :ys -1}]]
-  (-> df-1
+  (-> (df-1)
       (g/with-column "xs" (g/array [4 5 6 1]))
       (g/select
         (g/reverse "xs")
@@ -316,24 +316,24 @@
         (g/transform "xs" g/inc))
       g/collect-vals
       first) => [[1 6 5 4] 4 [5] [1 4 5 6] [6 5 4 1] 1 6 [4 5 6 1] [5 6 7 2]]
-  (-> df-1
+  (-> (df-1)
       (g/select (g/shuffle (g/array (range 10))))
       g/collect-vals
       flatten
       set) => (set (range 10))
-  (-> df-1
+  (-> (df-1)
       (g/select (g/flatten (g/array [(g/array (range 10))])))
       g/collect-vals
       ffirst) => (range 10)
-  (-> df-1
+  (-> (df-1)
       (g/select (-> (g/split :Regionname " ") (g/as :split)))
       (g/collect-col :split)) => [["Northern" "Metropolitan"]]
-  (-> df-1
+  (-> (df-1)
       (g/select (-> (g/sequence 1 3 1) (g/as :range)))
       (g/collect-col :range)) => [[1 2 3]])
 
 (fact "On random functions" :slow
-  (-> df-20
+  (-> (df-20)
       (g/select
         (-> (g/randn 0) (g/as :norm))
         (-> (g/rand 0) (g/as :unif)))
@@ -342,7 +342,7 @@
         (g/round (g/kurtosis :unif))
         (g/round (g/covar :unif :norm)))
       g/collect-vals) => [[0.0 -1.0 0.0]]
-  (-> df-20
+  (-> (df-20)
       (g/select
         (-> (g/randn) (g/as :norm))
         (-> (g/rand) (g/as :unif)))
@@ -353,11 +353,11 @@
       flatten) => #(every? pos? %))
 
 (fact "On trig functions"
-  (-> df-1
+  (-> (df-1)
       (g/select (g/atan2 1 2))
       g/collect-vals
       ffirst) => #(< 0.463 % 0.464)
-  (-> df-1
+  (-> (df-1)
       (g/select
         (g/- (g// (g/sin g/pi) (g/cos g/pi)) (g/tan g/pi))
         (g/- (g// g/pi 2)
@@ -373,7 +373,7 @@
       flatten) => (fn [xs] (every? #(< (Math/abs %) 0.001) xs)))
 
 (fact "On partition ID" :slow
-  (-> df-20
+  (-> (df-20)
       (g/repartition 3)
       (g/select (g/spark-partition-id))
       g/collect-vals
@@ -383,11 +383,11 @@
 
 (facts "On formatting"
   (fact "should format number correctly"
-    (-> df-1
+    (-> (df-1)
         (g/select (g/format-number 1234.56789 2))
         g/collect-vals) => [["1,234.57"]])
   (fact "should format strings correctly"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/format-string "(Rooms=%d, SellerG=%s)" [:Rooms :SellerG])
           (g/format-string "(Rooms=%d, SellerG=%s)" :Rooms :SellerG)
@@ -407,14 +407,14 @@
                              "Metropolitan"]]))
 
 (fact "On arithmetic functions"
-  (-> df-1
+  (-> (df-1)
       (g/select
         (-> (g/+ {:a 6 :b 2}))
         (-> (g/- {:a 6 :b 2}))
         (-> (g/* {:a 6 :b 2}))
         (-> (g// {:a 6 :b 2})))
       g/collect-vals) => [[8 4 12 3.0]]
-  (-> df-1
+  (-> (df-1)
       (g/select
         (-> (g/mod 19 7))
         (-> (g/between 1 0 2))
@@ -422,7 +422,7 @@
         (-> (g/nan? 0))
         (-> (g/cbrt 27)))
       g/collect-vals) => [[5 true false false 3.0]]
-  (-> df-1
+  (-> (df-1)
       (g/select
         (-> (g/* (g/log :Price) 0.5))
         (-> (g// (g/log :Price) 2.0))
@@ -432,20 +432,20 @@
       first
       distinct
       count) => 1
-  (-> df-1
+  (-> (df-1)
       (g/select :Price (-> (g/abs (g/negate :Price))))
       g/collect-vals
       first
       distinct
       count) => 1
-  (-> df-1 (g/select (g/+ 1 1)) g/collect-vals) => [[2]]
-  (-> df-1
+  (-> (df-1) (g/select (g/+ 1 1)) g/collect-vals) => [[2]]
+  (-> (df-1)
       (g/with-column "two" 2)
       (g/with-column "three" 3)
       (g/select (g/pow "two" "three"))
       g/collect-vals) => [[8.0]]
-  (-> df-1 (g/select (g/+) (g/*)) g/collect-vals) => [[0 1]]
-  (-> df-1
+  (-> (df-1) (g/select (g/+) (g/*)) g/collect-vals) => [[0 1]]
+  (-> (df-1)
       (g/select
         (g/=== (g/ceil 1.23)
                (g/floor 2.34)
@@ -457,7 +457,7 @@
       g/collect-vals) => [[true 1.0 0.0 1.0]])
 
 (facts "On group-by + agg functions" :slow
-  (let [summary (-> df-20
+  (let [summary (-> (df-20)
                     (g/agg
                       (g/count (g/->column :BuildingArea))
                       (list
@@ -486,20 +486,20 @@
             variance (summary (keyword "var_samp(Price)"))]
         (Math/abs (- (Math/pow std-dev 2) variance))) => #(< % 1e-6))
     (fact "count distinct and approx count distinct should be similar"
-      (-> df-50
+      (-> (df-50)
           (g/agg
             (-> (g/count-distinct :SellerG))
             (-> (g/approx-count-distinct :SellerG)))
           g/collect-vals
           first) => #(< 0.95 (/ (first %) (second %)) 1.05)
-      (-> df-50
+      (-> (df-50)
           (g/agg
             (g/count-distinct :SellerG)
             (g/approx-count-distinct :SellerG 0.1))
           g/collect-vals
           first) => #(< 0.9 (/ (first %) (second %)) 1.1))
     (fact "count distinct can take a map"
-      (-> df-50
+      (-> (df-50)
           (g/agg
             (g/count-distinct {:seller :SellerG
                                :suburb :Suburb}))
@@ -507,31 +507,31 @@
 
 (facts "On window functions" :slow
   (let [window  (g/window {:partition-by :SellerG :order-by :Price})]
-    (-> df-20
+    (-> (df-20)
         (g/select
           (-> (g/cume-dist) (g/over window))
           (-> (g/percent-rank) (g/over window)))
         g/collect-vals) => #(every? double? (flatten %))
-    (-> df-20
+    (-> (df-20)
         (g/select
           (-> (g/rank) (g/over window))
           (-> (g/dense-rank) (g/over window))
           (-> (g/ntile 2) (g/over window)))
         g/collect-vals) => #(every? int? (flatten %))
-    (-> df-20
+    (-> (df-20)
         (g/select
           (-> (g/lag :Price 1) (g/over window))
           (-> (g/lag :Price 1 -999) (g/over window)))
         g/collect-vals) => #(and (nil? (ffirst %))
                                  (= -999.0 (second (first %))))
-    (-> df-20
+    (-> (df-20)
         (g/select
           (-> (g/lead :Price 1) (g/over window))
           (-> (g/lead :Price 1 -999) (g/over window)))
         g/collect-vals) => #(and (nil? (first (last %)))
                                  (= -999.0 (second (last %)))))
   (fact "shortcut windowed works"
-    (-> df-20
+    (-> (df-20)
         (g/select
           :SellerG
           {:rank-by-suburb (g/windowed {:window-col   (g/rank)
@@ -545,7 +545,7 @@
 (facts "On windowing" :slow
   (fact "can instantiate empty WindowSpec"
     (g/window {}) => #(instance? WindowSpec %))
-  (let [records    (-> df-20
+  (let [records    (-> (df-20)
                        (g/select
                          :SellerG
                          (-> (g/max :Price)
@@ -563,7 +563,7 @@
     => (fn [pairs] (every? #(< (first %) (second %)) pairs))
     (map :row-num records) => [1 2 3 4])
   (fact "count rows last week"
-    (-> df-20
+    (-> (df-20)
         (g/select (-> (g/unix-timestamp :Date "d/MM/yyyy") (g/as :date)))
         (g/select
           (-> (g/count "*")
@@ -574,7 +574,7 @@
         flatten
         set) => #{1 2 3})
   (fact "count rows in the last two rows"
-    (-> df-20
+    (-> (df-20)
         (g/select (-> (g/unix-timestamp :Date "d/MM/yyyy") (g/as :date)))
         (g/select
           (-> (g/count "*")
@@ -587,7 +587,7 @@
 
 (facts "On time functions"
   (fact "correct time bucketisation"
-    (let [dataframe (-> df-20
+    (let [dataframe (-> (df-20)
                          (g/with-column :date (g/to-date :Date "d/MM/yyyy")))]
       (-> dataframe
           (g/select (g/time-window :date "7 days"))
@@ -602,7 +602,7 @@
           g/distinct
           g/count) => #(<= 28 % 32)))
   (fact "correct time arithmetic"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (-> (g/to-timestamp (g/lit "2020-05-12")))
           (-> (g/to-timestamp (g/lit "2020-05-12") "yyyy-MM-dd"))
@@ -613,7 +613,7 @@
                                            (instance? java.sql.Timestamp x1)
                                            (instance? java.sql.Date x2)
                                            (instance? java.sql.Date x3)))
-    (-> df-1
+    (-> (df-1)
         (g/select (g/to-utc-timestamp (g/lit "2020-05-12")))
         g/collect-vals
         ffirst
@@ -621,24 +621,24 @@
     (let [ts 1
           dt (-> (Instant/ofEpochMilli 1)
                  (.atZone (ZoneId/systemDefault)))]
-      (-> df-1
+      (-> (df-1)
           (g/select (g/from-unixtime ts))
           g/collect-vals
           ffirst) => #(.contains % (.format dt (DateTimeFormatter/ofPattern "yyyy-MM-dd ")))
-      (-> df-1
+      (-> (df-1)
           (g/select (g/from-unixtime ts "yyyy/MM/d HH:mm"))
           g/collect-vals
           ffirst) => (.format dt (DateTimeFormatter/ofPattern "yyyy/MM/d HH:mm")))
-    (-> df-1
+    (-> (df-1)
         (g/select (g/quarter (g/lit "2020-05-12")))
         g/collect-vals
         ffirst) => 2
-    (-> df-1
+    (-> (df-1)
         (g/select (g/date-trunc "YYYY" (g/to-timestamp (g/lit "2020-05-12"))))
         g/collect-vals
         ffirst
         .getTime) => #(= (mod % 10000) 0)
-    (-> df-1
+    (-> (df-1)
         (g/select
           (-> (g/last-day (g/lit "2020-05-12")) (g/cast "string"))
           (-> (g/next-day (g/lit "2020-02-01") "Sunday") (g/cast "string"))
@@ -657,7 +657,7 @@
                              23
                              -3.0]])
   (fact "correct current times"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (g/cast (g/current-timestamp) "string")
           (g/cast (g/current-date) "string"))
@@ -665,7 +665,7 @@
         flatten) => #(and (clojure.string/includes? (first %) ":")
                           (not (clojure.string/includes? (second %) ":"))))
   (fact "correct time comparisons"
-    (-> df-1
+    (-> (df-1)
         (g/select
           (-> (g/unix-timestamp) (g/as "now"))
           (-> (g/unix-timestamp (g/lit "2020/04/17") "yyyy/MM/dd") (g/as "past"))
@@ -680,7 +680,7 @@
         g/collect-vals) => #(every? identity (flatten %)))
   (fact "correct time extraction"
     (let [date (g/lit "1930-12-30 13:15:05")]
-      (-> df-1
+      (-> (df-1)
           (g/select
             (-> (g/year date) (g/as "year"))
             (-> (g/month date) (g/as "month"))
@@ -701,8 +701,8 @@
                      :year 1930})))
 
 (fact "hashing should give unique rows" :slow
-  (let [n-sellers (-> df-20 (g/select :SellerG) g/distinct g/count)]
-    (-> df-20 (g/select (g/xxhash64 :SellerG)) g/distinct g/count) => n-sellers
-    (-> df-20 (g/select (g/md5 :SellerG)) g/distinct g/count) => n-sellers
-    (-> df-20 (g/select (g/sha1 :SellerG)) g/distinct g/count) => n-sellers
-    (-> df-20 (g/select (g/sha2 :SellerG 256)) g/distinct g/count) => n-sellers))
+  (let [n-sellers (-> (df-20) (g/select :SellerG) g/distinct g/count)]
+    (-> (df-20) (g/select (g/xxhash64 :SellerG)) g/distinct g/count) => n-sellers
+    (-> (df-20) (g/select (g/md5 :SellerG)) g/distinct g/count) => n-sellers
+    (-> (df-20) (g/select (g/sha1 :SellerG)) g/distinct g/count) => n-sellers
+    (-> (df-20) (g/select (g/sha2 :SellerG 256)) g/distinct g/count) => n-sellers))

--- a/test/zero_one/geni/streaming_test.clj
+++ b/test/zero_one/geni/streaming_test.clj
@@ -5,9 +5,10 @@
     [clojure.string :as string]
     [midje.sweet :refer [facts fact throws =>]]
     [zero-one.geni.aot-functions :as aot]
-    [zero-one.geni.defaults :as defaults]
+    ;[zero-one.geni.defaults :as defaults]
     [zero-one.geni.rdd :as rdd]
-    [zero-one.geni.streaming :as streaming])
+    [zero-one.geni.streaming :as streaming]
+    [zero-one.geni.test-resources :as tr])
   (:import
     (org.apache.spark.api.java JavaSparkContext)
     (org.apache.spark.streaming Duration StreamingContext Time)
@@ -33,7 +34,7 @@
 
 (defn stream-results [opts]
   (let [context         (streaming/streaming-context
-                          @defaults/spark
+                          @tr/spark
                           (streaming/milliseconds (:duration-ms opts 100)))
         read-file      (create-random-temp-file! "read.txt")
         write-file     (create-random-temp-file! "write")
@@ -206,7 +207,7 @@
     (streaming/->time 123) => (Time. 123)))
 
 (facts "On StreamingContext" :streaming
-       (let [context (streaming/streaming-context @defaults/spark 1000)]
+       (let [context (streaming/streaming-context @tr/spark 1000)]
          (fact "streaming context instantiatable"
                context => (partial instance? JavaStreamingContext))
          (fact "expected basic fields and methods"

--- a/test/zero_one/geni/tech_ml_test.clj
+++ b/test/zero_one/geni/tech_ml_test.clj
@@ -5,13 +5,13 @@
     [zero-one.geni.test-resources :refer [create-temp-file! melbourne-df]]))
 
 (def dummy-df
-  (-> melbourne-df (g/select :Method) (g/limit 5)))
+  (-> (melbourne-df) (g/select :Method) (g/limit 5)))
 
 (fact "On rand-nth" :slow
   (g/rand-nth dummy-df) => map?
-  (g/rand-nth melbourne-df) => map?
-  (g/rand-nth (g/limit melbourne-df 1)) => map?
-  (g/rand-nth (g/limit melbourne-df 2)) => map?)
+  (g/rand-nth (melbourne-df)) => map?
+  (g/rand-nth (g/limit (melbourne-df) 1)) => map?
+  (g/rand-nth (g/limit (melbourne-df) 2)) => map?)
 
 (fact "On assoc and dissoc"
   (-> dummy-df

--- a/test/zero_one/geni/test_resources.clj
+++ b/test/zero_one/geni/test_resources.clj
@@ -45,8 +45,11 @@
 (def -tmp-dir-attr
   (into-array FileAttribute '()))
 
-(defn create-temp-file! [extension]
-  (let [temp-dir (.toFile (Files/createTempDirectory "tmp-dir" -tmp-dir-attr))]
+(defn create-temp-dir! ^File []
+  (.toFile (Files/createTempDirectory "tmp-dir-" -tmp-dir-attr)))
+
+(defn create-temp-file! ^File [extension]
+  (let [temp-dir (create-temp-dir!)]
     (File/createTempFile "temporary" extension temp-dir)))
 
 (defn recursive-delete-dir

--- a/test/zero_one/geni/test_resources.clj
+++ b/test/zero_one/geni/test_resources.clj
@@ -1,31 +1,37 @@
 (ns zero-one.geni.test-resources
   (:require
-    [clojure.string :refer [split-lines split]]
+    [clojure.string :refer [split-lines split] :as string]
     [zero-one.geni.core :as g]
-    [zero-one.geni.defaults])
+    [zero-one.geni.defaults]
+    [clojure.java.io :as io])
   (:import
     (java.io File)
     (java.nio.file.attribute FileAttribute)
-    (java.nio.file Files)))
+    (java.nio.file Files Paths)
+    (java.util UUID)))
 
-(def spark @zero-one.geni.defaults/spark)
 
-(def melbourne-df
-  (g/cache (g/read-parquet! spark "test/resources/melbourne_housing_snapshot.parquet")))
+(def spark zero-one.geni.defaults/spark)
 
-(def df-1 (g/limit melbourne-df 1))
+(defn melbourne-df []
+  (g/read-parquet! @spark "test/resources/melbourne_housing_snapshot.parquet"))
 
-(def df-20 (g/limit melbourne-df 20))
+(defn df-1 []
+  (g/limit (melbourne-df) 1))
 
-(def df-50 (g/limit melbourne-df 50))
+(defn df-20 []
+  (g/limit (melbourne-df) 20))
 
-(def libsvm-df
-  (g/read-libsvm! spark "test/resources/sample_libsvm_data.txt" {:num-features "780"}))
+(defn df-50 []
+  (g/limit (melbourne-df) 50))
 
-(def k-means-df
-  (g/read-libsvm! spark "test/resources/sample_kmeans_data.txt" {:num-features "780"}))
+(defn libsvm-df []
+  (g/read-libsvm! @spark "test/resources/sample_libsvm_data.txt" {:num-features "780"}))
 
-(def ratings-df
+(defn k-means-df []
+  (g/read-libsvm! @spark "test/resources/sample_kmeans_data.txt" {:num-features "780"}))
+
+(defn ratings-df []
   (->> (slurp "test/resources/sample_movielens_ratings.txt")
        split-lines
        (map #(split % #"::"))
@@ -34,7 +40,7 @@
                :movie-id  (Integer/parseInt (second row))
                :rating    (Float/parseFloat (nth row 2))
                :timestamp (long (Integer/parseInt (nth row 3)))}))
-       (g/records->dataset spark)))
+       (g/records->dataset @spark)))
 
 (def -tmp-dir-attr
   (into-array FileAttribute '()))
@@ -42,3 +48,32 @@
 (defn create-temp-file! [extension]
   (let [temp-dir (.toFile (Files/createTempDirectory "tmp-dir" -tmp-dir-attr))]
     (File/createTempFile "temporary" extension temp-dir)))
+
+(defn recursive-delete-dir
+  [^File file]
+  (when (.isDirectory file)
+    (doseq [file-in-dir (.listFiles file)]
+      (recursive-delete-dir file-in-dir)))
+  (io/delete-file file))
+
+(defn delete-warehouse!
+  []
+  (let [wh-path (-> @spark .conf (.get "spark.sql.warehouse.dir") (string/replace "file:" ""))
+        wh-dir (File. wh-path)]
+    (when (.exists wh-dir)
+      (recursive-delete-dir wh-dir))))
+
+(def test-warehouses-root
+  (str (Paths/get (.getAbsolutePath (io/file "")) (into-array String ["spark-warehouses"]))))
+
+(defn rand-wh-path
+  []
+  (str "file:" (Paths/get test-warehouses-root (into-array String [(str (UUID/randomUUID))]))))
+
+(defn reset-session!
+  []
+  (.close @spark)
+  (reset! spark (g/create-spark-session
+                  (assoc-in zero-one.geni.defaults/session-config
+                            [:configs :spark.sql.warehouse.dir]
+                            (rand-wh-path)))))


### PR DESCRIPTION
This is a work-in-progress PR intended to get feedback on the API and create a place for discussion around spark session management for tests. As of the creation of the ticket, this version is passing tests with `lein midje` on my local machine but failing `make ci`.

This PR changes more files than I originally expected. If it is too extreme of a change, I would be happy to take a different approach.

### Background

Spark has two stateful locations that are used to manage tables when running locally.

1. The `spark_warehouse` is a directory specified by the session setting `spark.sql.warehouse.dir`. This is the location where every table's data files are stored.

2. The metastore is an in-memory database that stores metadata about each table (its location, etc.) 

Once we add the capability to read/write tables, our testing pattern must clear the state in these two places. If we have that, test expectations become, order independent, idempotent, generally easier to reason about. Also, we don't want to accumulate test tables on disk over time.

### Possible patterns (please flag anything I forgot!)

1. Dropping all managed tables between tests using SQL. This doesn't immediately delete the data in the warehouse. Relying on this alone leads to semi-random file-already-exists errors.

2. Deleting the warehouse directory between tests. This doesn't immediately delete the data in the metastore. Relying on this alone leads to semi-random table-already-exists errors.

3. Change the `spark.sql.warehouse.dir` between tests. Spark does not allow changing session level settings of an active spark session. The spark session must be stopped and a new one must be started.

In my other projects (and this PR) I leverage a combination of approach 3 and 2. For tests that touch managed tables, the session is restarted with a new `spark.sql.warehouse.dir` during "setup" and the warehouse directory is deleted during "tear-down". 

I am happy to go a different direction, if we can find one.

### Impact on the rest of the code-bsae.

There are 2 main changes that had to made in throughout the Geni codebase. 

1. The default spark session at `zero-one.geni.defaults/spark` was changed to an `atom` instead of `delay`. This may negatively impact the startup time, but I didn't measure it.

   This allows the spark session to be replaced by a new one with a different warehouse directory.

   My original design was to leave `zero-one.geni.defaults/spark` as a `delay` and use a different session for tests. The second session would be stored in an `atom` in `test-resources`. This ended up being a challenging approach because it became critical that the `defaults/spark` session delay not be touched throughout tests. It might be work revisiting this idea and spend more time stomping out any reference to `zero-one.geni.defaults/spark` in the tests.

2. Old spark session can't leak between tests. For example, the Datasets in `test-resources` are created with the initial spark session. If that session is closed between tests, the Dataset becomes unreadable.

   To address this, I changed all the test-resources to functions that create a new Dataset using the current spark session in the atom.

@anthony-khong I would like to get your thoughts before I flesh out the tests. Also, any input on the `make ci` failure would be much appreciated. That one currently has me stumped, but I will keep working on it. 