### PR TITLE
Reformat style using `lein cljfmt` on small sample

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,13 +23,6 @@
   :url "https://github.com/zero-one-group/geni"
   :license {:name "Apache License"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
-  :plugins [[lein-cljfmt "0.7.0"]]
-  :cljfmt {:split-keypairs-over-multiple-lines?   false
-           :remove-multiple-non-indenting-spaces? false
-           ;; Note: we add custom rules to handle code from midje test library
-           ;; See: https://github.com/weavejester/cljfmt/blob/master/cljfmt/resources/cljfmt/indents/clojure.clj ;; for more control
-           :indents {facts [[:inner 0] [:block 1]]
-                     fact  [[:inner 0] [:block 1]]}}
   :dependencies [[camel-snake-kebab "0.4.1"]
                  [expound "0.8.6"]
                  [metosin/jsonista "0.2.7"
@@ -48,7 +41,14 @@
                         [midje "1.9.9"]]
          :plugins [[lein-ancient "0.6.15"]
                    [lein-cloverage "1.2.1"]
-                   [lein-midje "3.2.2"]]
+                   [lein-midje "3.2.2"]
+                   [lein-cljfmt "0.7.0"]]
+         :cljfmt {:split-keypairs-over-multiple-lines?   false
+                  :remove-multiple-non-indenting-spaces? false
+                  ;; Note: we add custom rules to handle code from midje test library
+                  ;; See: https://github.com/weavejester/cljfmt/blob/master/cljfmt/resources/cljfmt/indents/clojure.clj ;; for more control
+                  :indents {facts [[:inner 0] [:block 1]]
+                            fact  [[:inner 0] [:block 1]]}}
          :aot [zero-one.geni.rdd.function
                zero-one.geni.aot-functions]}}
   :repl-options {:init-ns zero-one.geni.main}

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,13 @@
   :url "https://github.com/zero-one-group/geni"
   :license {:name "Apache License"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
+  :plugins [[lein-cljfmt "0.7.0"]]
+  :cljfmt {:split-keypairs-over-multiple-lines?   false
+           :remove-multiple-non-indenting-spaces? false
+           ;; Note: we add custom rules to handle code from midje test library
+           ;; See: https://github.com/weavejester/cljfmt/blob/master/cljfmt/resources/cljfmt/indents/clojure.clj ;; for more control
+           :indents {facts [[:inner 0] [:block 1]]
+                     fact  [[:inner 0] [:block 1]]}}
   :dependencies [[camel-snake-kebab "0.4.1"]
                  [expound "0.8.6"]
                  [metosin/jsonista "0.2.7"

--- a/src/clojure/zero_one/geni/rdd.clj
+++ b/src/clojure/zero_one/geni/rdd.clj
@@ -16,73 +16,73 @@
                             take
                             vals])
   (:require
-    [potemkin :refer [import-vars]]
-    [zero-one.geni.defaults]
-    [zero-one.geni.interop :as interop]
-    [zero-one.geni.partial-result]
-    [zero-one.geni.rdd.function :as function]
-    [zero-one.geni.rdd.unmangle :as unmangle]
-    [zero-one.geni.spark-context]
-    [zero-one.geni.storage])
+   [potemkin :refer [import-vars]]
+   [zero-one.geni.defaults]
+   [zero-one.geni.interop :as interop]
+   [zero-one.geni.partial-result]
+   [zero-one.geni.rdd.function :as function]
+   [zero-one.geni.rdd.unmangle :as unmangle]
+   [zero-one.geni.spark-context]
+   [zero-one.geni.storage])
   (:import
-    (org.apache.spark.partial PartialResult)
-    (org.apache.spark.api.java JavaRDD JavaSparkContext)))
+   (org.apache.spark.partial PartialResult)
+   (org.apache.spark.api.java JavaRDD JavaSparkContext)))
 
 (def rdd? (partial instance? JavaRDD))
 
 (import-vars
-  [zero-one.geni.spark-context
-   app-name
-   binary-files
-   broadcast
-   checkpoint-dir
-   conf
-   default-min-partitions
-   default-parallelism
-   empty-rdd
-   is-local
-   jars
-   java-spark-context
-   local-property
-   local?
-   master
-   parallelise
-   parallelise-doubles
-   parallelise-pairs
-   parallelize
-   parallelize-doubles
-   parallelize-pairs
-   persistent-rdds
-   resources
-   sc
-   spark-context
-   spark-home
-   text-file
-   value
-   version
-   whole-text-files])
+ [zero-one.geni.spark-context
+  app-name
+  binary-files
+  broadcast
+  checkpoint-dir
+  conf
+  default-min-partitions
+  default-parallelism
+  empty-rdd
+  is-local
+  jars
+  java-spark-context
+  local-property
+  local?
+  master
+  parallelise
+  parallelise-doubles
+  parallelise-pairs
+  parallelize
+  parallelize-doubles
+  parallelize-pairs
+  persistent-rdds
+  resources
+  sc
+  spark-context
+  spark-home
+  text-file
+  value
+  version
+  whole-text-files])
 
 (import-vars
-  [zero-one.geni.storage
-   disk-only
-   disk-only-2
-   memory-and-disk
-   memory-and-disk-2
-   memory-and-disk-ser
-   memory-and-disk-ser-2
-   memory-only
-   memory-only-2
-   memory-only-ser
-   memory-only-ser-2
-   none
-   off-heap])
+ [zero-one.geni.storage
+  disk-only
+  disk-only-2
+  memory-and-disk
+  memory-and-disk-2
+  memory-and-disk-ser
+  memory-and-disk-ser-2
+  memory-only
+  memory-only-2
+  memory-only-ser
+  memory-only-ser-2
+  none
+  off-heap])
 
 (import-vars
-  [zero-one.geni.partial-result
-   final-value
-   final?
-   initial-value
-   is-initial-value-final])
+ [zero-one.geni.partial-result
+  final-value
+  final?
+  initial-value
+  is-initial-value-final])
 
 ;; Getters
 (defn context [rdd] (JavaSparkContext/fromSparkContext (.context rdd)))
@@ -192,8 +192,8 @@
   ([rdd f] (map-partitions-to-pair rdd f false))
   ([rdd f preserves-partitioning]
    (-> (.mapPartitionsToPair rdd
-                            (function/pair-flat-map-function f)
-                            preserves-partitioning)
+                             (function/pair-flat-map-function f)
+                             preserves-partitioning)
        (unmangle/unmangle-name f))))
 
 (defn map-partitions-with-index
@@ -349,7 +349,7 @@
   ([rdd with-replacement n]
    (-> rdd (.takeSample with-replacement n) seq interop/->clojure))
   ([rdd with-replacement n seed] (.takeSample rdd with-replacement n seed)
-   (-> rdd (.takeSample with-replacement n) seq interop/->clojure)))
+                                 (-> rdd (.takeSample with-replacement n) seq interop/->clojure)))
 
 (defn top
   ([rdd n] (-> rdd (.top n) seq interop/->clojure))
@@ -385,10 +385,10 @@
                                merge-combiner-fn)))
   ([rdd create-fn merge-value-fn merge-combiner-fn partitions-or-partitioner]
    (-> (.combineByKey rdd
-                     (function/function create-fn)
-                     (function/function2 merge-value-fn)
-                     (function/function2 merge-combiner-fn)
-                     partitions-or-partitioner)
+                      (function/function create-fn)
+                      (function/function2 merge-value-fn)
+                      (function/function2 merge-combiner-fn)
+                      partitions-or-partitioner)
        (unmangle/unmangle-name create-fn
                                merge-value-fn
                                merge-combiner-fn

--- a/src/clojure/zero_one/geni/rdd/function.clj
+++ b/src/clojure/zero_one/geni/rdd/function.clj
@@ -1,10 +1,10 @@
 ;; Taken from https://github.com/amperity/sparkplug
 (ns zero-one.geni.rdd.function
   (:require
-    [clojure.string :as str])
+   [clojure.string :as str])
   (:import
-    (java.lang.reflect Field Modifier)
-    (java.util HashSet)))
+   (java.lang.reflect Field Modifier)
+   (java.util HashSet)))
 
 (defn access-field [^Field field obj]
   (try
@@ -28,14 +28,14 @@
       (do
         (when (map? obj)
           (doall
-            (for [entry obj]
-              (walk-object-vars references visited entry))))
+           (for [entry obj]
+             (walk-object-vars references visited entry))))
         (doall
-          (for [^Field field (.getDeclaredFields (class obj))]
-            (when (or (not (map? obj)) (Modifier/isStatic (.getModifiers field)))
-              (let [value (access-field field obj)]
-                (when (or (ifn? value) (map? value))
-                  (walk-object-vars references visited value))))))))))
+         (for [^Field field (.getDeclaredFields (class obj))]
+           (when (or (not (map? obj)) (Modifier/isStatic (.getModifiers field)))
+             (let [value (access-field field obj)]
+               (when (or (ifn? value) (map? value))
+                 (walk-object-vars references visited value))))))))))
 
 (defn namespace-references [^Object obj]
   (let [obj-ns (-> (.. obj getClass getName)

--- a/src/clojure/zero_one/geni/rdd/unmangle.clj
+++ b/src/clojure/zero_one/geni/rdd/unmangle.clj
@@ -1,9 +1,9 @@
 ;; Taken from https://github.com/amperity/sparkplug
 (ns zero-one.geni.rdd.unmangle
   (:require
-    [clojure.string :as string])
+   [clojure.string :as string])
   (:import
-    (clojure.lang Compiler)))
+   (clojure.lang Compiler)))
 
 (defn- internal-call?  [^StackTraceElement element]
   (let [class-name (.getClassName element)]


### PR DESCRIPTION
I ran the following command to re-format the code 

```
lein cljfmt fix src/clojure/zero_one/geni/rdd/
lein cljfmt fix src/clojure/zero_one/geni/rdd.clj
```
Please review and let me know if you like to adjust the rules going forward.
Thanks