### PR TITLE
Adds partial Delta Lake support

### DIFF
--- a/docker/project.clj
+++ b/docker/project.clj
@@ -9,6 +9,7 @@
     [org.apache.spark/spark-mllib_2.12 "3.1.1"]
     [org.apache.spark/spark-sql_2.12 "3.1.1"]
     [org.apache.spark/spark-streaming_2.12 "3.1.1"]
+    [io.delta/delta-core_2.12 "0.8.0"]
     ; Arrow
     [org.apache.arrow/arrow-memory-netty "3.0.0"]
     [org.apache.arrow/arrow-memory-core "3.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
     [org.apache.spark/spark-mllib_2.12 "3.1.1"]
     [org.apache.spark/spark-sql_2.12 "3.1.1"]
     [org.apache.spark/spark-streaming_2.12 "3.1.1"]
+    [io.delta/delta-core_2.12 "0.8.0"]
     ; Arrow
     [org.apache.arrow/arrow-memory-netty "3.0.0"]
     [org.apache.arrow/arrow-memory-core "3.0.0"]

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -97,6 +97,8 @@
  [zero-one.geni.spark
   create-spark-session
   spark-conf
+  set-settings
+  with-settings
   sql])
 
 (import-vars

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -525,6 +525,7 @@
   read-avro!
   read-binary!
   read-csv!
+  read-delta!
   read-edn!
   read-jdbc!
   read-json!
@@ -535,6 +536,7 @@
   read-xlsx!
   write-avro!
   write-csv!
+  write-delta!
   write-edn!
   write-jdbc!
   write-json!

--- a/src/clojure/zero_one/geni/core.clj
+++ b/src/clojure/zero_one/geni/core.clj
@@ -480,6 +480,7 @@
   rollup
   sample
   sample-by
+  schema
   select
   select-expr
   show

--- a/src/clojure/zero_one/geni/core/data_sources.clj
+++ b/src/clojure/zero_one/geni/core/data_sources.clj
@@ -384,3 +384,31 @@
   view, e.g. `SELECT * FROM global_temp.view1`."
   [^Dataset dataframe ^String view-name]
   (.createOrReplaceGlobalTempView dataframe view-name))
+
+
+;; Delta
+(defmulti read-delta!
+  "Loads a delta table from a directory and returns the results as a DataFrame.
+
+   Spark's DataFrameReader options may be passed in as a map of options.
+
+   See: https://spark.apache.org/docs/latest/sql-data-sources.html
+   See: https://docs.delta.io/latest/quick-start.html#read-data"
+  (fn [head & _] (class head)))
+(defmethod read-delta! :default
+  ([path] (read-delta! @defaults/spark path))
+  ([path options] (read-delta! @defaults/spark path options)))
+(defmethod read-delta! SparkSession
+  ([spark path] (read-delta! spark path {}))
+  ([spark path options] (read-data! "delta" spark path options)))
+
+
+(defn write-delta!
+  "Writes a delta table at the specified path.
+
+   Spark's DataFrameWriter options may be passed in as a map of options.
+
+   See: https://spark.apache.org/docs/latest/sql-data-sources.html
+   See: https://docs.delta.io/latest/quick-start.html#create-a-table"
+  ([dataframe path] (write-delta! dataframe path {}))
+  ([dataframe path options] (write-data! "delta" dataframe path options)))

--- a/src/clojure/zero_one/geni/core/dataset.clj
+++ b/src/clojure/zero_one/geni/core/dataset.clj
@@ -13,7 +13,8 @@
    [zero-one.geni.interop :as interop]
    [zero-one.geni.utils :refer [ensure-coll]])
   (:import
-   (org.apache.spark.sql Column)))
+    (org.apache.spark.sql Column Dataset)
+    (org.apache.spark.sql.types StructType)))
 
 ;;;; Actions
 (defn- collected->maps [collected]
@@ -37,6 +38,10 @@
 
 (defn take [dataframe n-rows]
   (-> dataframe (.take n-rows) collected->maps))
+
+(defn schema ^StructType
+  [^Dataset dataframe]
+  (.schema dataframe))
 
 (defn show
   ([dataframe] (show dataframe {}))

--- a/src/clojure/zero_one/geni/defaults.clj
+++ b/src/clojure/zero_one/geni/defaults.clj
@@ -1,10 +1,15 @@
 (ns zero-one.geni.defaults
   (:require
-   [zero-one.geni.spark]))
+   [zero-one.geni.spark]
+   [zero-one.geni.interop :as iop]))
 
 (def session-config
-  {:configs {:spark.sql.adaptive.enabled "true"
-             :spark.sql.adaptive.coalescePartitions.enabled "true"}
+  {:configs (merge {:spark.sql.adaptive.enabled "true"
+                    :spark.sql.adaptive.coalescePartitions.enabled "true"}
+                   (when (iop/class-exists? 'io.delta.sql.DeltaSparkSessionExtension)
+                     ;; Required for writing Delta tables.
+                     {:spark.sql.extensions "io.delta.sql.DeltaSparkSessionExtension"
+                      :spark.sql.catalog.spark_catalog "org.apache.spark.sql.delta.catalog.DeltaCatalog"}))
    :checkpoint-dir "target/checkpoint/"})
 
 (def spark

--- a/src/clojure/zero_one/geni/delta.clj
+++ b/src/clojure/zero_one/geni/delta.clj
@@ -1,0 +1,205 @@
+(ns zero-one.geni.delta
+  (:refer-clojure :exclude [update merge])
+  (:require [clojure.spec.alpha :as s]
+            [zero-one.geni.core :as g]
+            [zero-one.geni.defaults :as defaults]
+            [zero-one.geni.interop :as i]
+            [zero-one.geni.utils :refer [with-dynamic-import]])
+  (:import (org.apache.spark.sql Column Dataset SparkSession)
+           (java.util Map)))
+
+(s/def ::format #{:path :table})
+(s/def ::column-name (s/or :kw keyword? :str string?))
+(s/def ::column #(instance? Column %))
+(s/def ::condition ::column)
+(s/def ::on-match #{:delete :update})
+(s/def ::on-not-match #{:insert})
+
+(s/def ::column-rule
+  (s/or :some (s/map-of ::column-name ::column)
+        :all #{:all}))
+
+(s/def ::when-matched-clause
+  (s/keys :req [::on-match ::column-rule]
+          :opt [::condition]))
+
+(s/def ::when-matched
+  (s/coll-of ::when-matched-clause :kind sequential? :max-count 2))
+
+(s/def ::when-not-matched
+  (s/keys :req [::on-not-match ::column-rule]
+          :opt [::condition]))
+
+(s/def ::merge-strategy
+  (s/keys :req [::condition]
+          :opt [::when-matched ::when-not-matched]))
+
+;; @todo Uncomment this code once Delta has been upgraded to support Spark 3.1.x
+;; This code has been tested against Spark 3.0.2
+;(defn validate-merge-strategy
+;  "
+;  See constraints: https://docs.delta.io/latest/api/scala/io/delta/tables/DeltaMergeBuilder.html"
+;  [merge-strategy]
+;  {:pre [(s/valid? ::merge-strategy merge-strategy)]}
+;  (let [when-matched (get merge-strategy ::when-matched [])]
+;    ; There can be at most one `update` action and one `delete` action in when-matched clauses.
+;    (let [clause-counts (->> when-matched
+;                             (group-by ::on-match)
+;                             (map (fn [[k v]] [k (count v)])))]
+;      (when (> (count clause-counts) 2)
+;        (ex-info (str "Found more than 2 `when-matched` clauses in a Delta merge strategy. There can only be 1 update and 1 delete.")
+;                 {:clause-kinds    (keys clause-counts)
+;                  ::merge-strategy merge-strategy}))
+;      (doseq [[clause-kind clause-count] clause-counts]
+;        (when (> clause-count 1)
+;          (ex-info (str "Found multiple " clause-kind " clauses in a Delta merge strategy.")
+;                   {:clause-kind     clause-kind
+;                    :clause-count    clause-count
+;                    ::merge-strategy merge-strategy}))))
+;
+;    ; If there are two when-matched clauses, then the first one must have a condition.
+;    (when (and (= (count when-matched) 2)
+;               (= (::column-rule (first when-matched)) :all))
+;      (ex-info "When using two when-matched clauses in a Delta merge the first one must have a condition, not :all."
+;               {::merge-strategy merge-strategy})))
+;  true)
+;
+;(defn- prepare-update-set-map ^Map
+;  [m]
+;  (->> m
+;       (map (fn [[k v]] [(name k) (g/col v)]))
+;       (into {})))
+
+(with-dynamic-import
+  [[io.delta.tables DeltaTable DeltaMergeBuilder]]
+
+  (defn delta-table ^DeltaTable
+    ([opts] (delta-table @defaults/spark opts))
+    ([^SparkSession spark {:keys [format location] :or {format :path}}]
+     {:pre [(s/valid? ::format format)]}
+     (if (= format :path)
+       (. DeltaTable forPath spark location)
+       (. DeltaTable forName spark location))))
+
+  (defn delta-table?
+    ([^String identifier]
+     (DeltaTable/isDeltaTable identifier))
+    ([^SparkSession spark ^String identifier]
+     (DeltaTable/isDeltaTable spark identifier)))
+
+  (defn as ^DeltaTable
+    [^DeltaTable table ^String alias]
+    ;; @todo move to polymorphic.clj? How to handle dynamic import in multimethod?
+    (.as table alias))
+
+  (defn to-df ^Dataset
+    [^DeltaTable table]
+    ;; @todo move to polymorphic.clj? How to handle dynamic import in multimethod?
+    (.toDF table))
+
+  (defmulti convert-to-delta (fn [head & _] (class head)))
+  (defmethod convert-to-delta :default
+    [^String identifier & {:keys [partition-schema]}]
+    (convert-to-delta @defaults/spark identifier :partition-schema partition-schema))
+  (defmethod convert-to-delta SparkSession
+    [^SparkSession spark ^String identifier & {:keys [partition-schema]}]
+    (if (nil? partition-schema)
+      (DeltaTable/convertToDelta spark identifier)
+      (DeltaTable/convertToDelta spark identifier (g/->schema partition-schema))))
+
+  (defmulti delete (fn [& args] (class (last args))))
+  (defmethod delete :default
+    [^DeltaTable table]
+    (.delete table))
+  (defmethod delete Column
+    [^DeltaTable table ^Column condition]
+    (.delete table condition))
+
+  (defn history ^Dataset
+    ([^DeltaTable table]
+     (.history table))
+    ([^DeltaTable table ^Integer limit]
+     (.history table limit)))
+
+  (defn vacuum
+    ([^DeltaTable table]
+     (.vacuum table))
+    ([^DeltaTable table ^Double retention-hours]
+     (.vacuum table retention-hours)))
+
+  ;; @todo Uncomment this code once Delta has been upgraded to support Spark 3.1.x
+  ;; This code has been tested against Spark 3.0.2
+  ;(defn update
+  ;  ;; @todo Update is broken with Spark 3.1 + Delta 0.8. upgrade Delta ASAP.
+  ;  ;; https://github.com/delta-io/delta/issues/594
+  ;  ([^DeltaTable table set-to]
+  ;   (let [m (prepare-update-set-map set-to)]
+  ;     (.update table m)))
+  ;  ([^DeltaTable table ^Column condition set-to]
+  ;   (.update table condition (prepare-update-set-map set-to))))
+  ;
+  ;(defn- apply-when-matched-clause ^DeltaMergeBuilder
+  ;  [^DeltaMergeBuilder merge-builder when-matched-clause]
+  ;  (let [{:zero-one.geni.delta/keys [condition on-match column-rule]} when-matched-clause
+  ;        on-match-builder (if (nil? condition)
+  ;                           (.whenMatched merge-builder)
+  ;                           (.whenMatched merge-builder condition))]
+  ;    (cond
+  ;      (and (= on-match :update) (= column-rule :all))
+  ;      (.updateAll on-match-builder)
+  ;
+  ;      (= on-match :update)
+  ;      (let [scala-column-rule (->> column-rule
+  ;                                   (map (fn [[k column]] [(name k) column]))
+  ;                                   (into {})
+  ;                                   (i/->scala-map))]
+  ;        (.update on-match-builder scala-column-rule))
+  ;
+  ;      (and (= on-match :delete) (= column-rule :all))
+  ;      (.delete on-match-builder)
+  ;
+  ;      (= on-match :delete)
+  ;      (ex-info "If a Delta merge `when-matched` clause is set to `delete`, it must use the column-rule `all`."
+  ;               {::when-matched-clause when-matched-clause})
+  ;
+  ;      :else
+  ;      (ex-info (str "Unknown `on-match` for Delta merge strategy.")
+  ;               {::when-matched-clause when-matched-clause}))))
+  ;
+  ;(defn- apply-when-not-matched ^DeltaMergeBuilder
+  ;  [^DeltaMergeBuilder merge-builder when-not-matched]
+  ;  (let [{:zero-one.geni.delta/keys [on-not-match column-rule condition]} when-not-matched
+  ;        not-match-builder (if (nil? condition)
+  ;                            (.whenNotMatched merge-builder)
+  ;                            (.whenNotMatched merge-builder condition))]
+  ;    (cond
+  ;      (and (= on-not-match :insert) (= column-rule :all))
+  ;      (.insertAll not-match-builder)
+  ;
+  ;      (= on-not-match :insert)
+  ;      (let [scala-column-rule (->> column-rule
+  ;                                   (map (fn [[k column]] [(name k) column]))
+  ;                                   (into {})
+  ;                                   (i/->scala-map))]
+  ;        (.insert not-match-builder scala-column-rule))
+  ;
+  ;      :else
+  ;      (ex-info (str "Unknown `on-not-match` for Delta merge strategy.")
+  ;               {::when-not-matched when-not-matched}))))
+  ;
+  ;(defn merge
+  ;  [^DeltaTable destination ^Dataset source merge-strategy]
+  ;  {:pre [(validate-merge-strategy merge-strategy)]}
+  ;  ;; @todo Update is broken with Spark 3.1 + Delta 0.8. upgrade Delta ASAP.
+  ;  ;; https://github.com/delta-io/delta/issues/594
+  ;  (let [merge-builder (.merge destination source (::condition merge-strategy))
+  ;        with-on-matched (reduce (fn [builder clause]
+  ;                                  (apply-when-matched-clause builder clause))
+  ;                                merge-builder
+  ;                                (get merge-strategy ::when-matched []))
+  ;        with-not-matched (let [clause (::when-not-matched merge-strategy)]
+  ;                           (if (nil? clause)
+  ;                             with-on-matched
+  ;                             (apply-when-not-matched with-on-matched clause)))]
+  ;    (.execute with-not-matched)))
+  )

--- a/test/zero_one/geni/delta_test.clj
+++ b/test/zero_one/geni/delta_test.clj
@@ -1,0 +1,189 @@
+(ns zero-one.geni.delta-test
+  (:require [midje.sweet :refer [facts fact => throws with-state-changes after before]]
+            [zero-one.geni.delta :as d]
+            [zero-one.geni.core :as g]
+            [zero-one.geni.test-resources :as tr])
+  (:import (java.io File)))
+
+(defn stable-collect [ds]
+  (-> ds g/to-df (g/order-by :id) g/collect))
+
+(facts "On Delta table creation"
+  (with-state-changes [(before :facts (tr/reset-session!))
+                       (after :facts (tr/delete-warehouse!))]
+    (fact "Can read and write paths"
+      (let [data (g/range 3)
+            table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")]
+        (g/write-delta! data table-path)
+        (let [delta-tbl (d/delta-table {:location table-path})]
+          (d/delta-table? table-path) => true
+          (g/collect (g/order-by (d/to-df delta-tbl) :id)) => (g/collect (g/order-by (g/to-df data) :id)))))
+    (fact "Can read and write managed tables"
+      (let [data (g/range 3)]
+        (g/write-table! data "test_tbl")
+        (d/convert-to-delta "test_tbl")
+        (let [delta-tbl (d/delta-table {:location "test_tbl"
+                                        :format   :table})]
+          (g/collect (g/order-by (d/to-df delta-tbl) :id)) => (g/collect (g/order-by (g/to-df data) :id)))))))
+
+(facts "On simple Delta operations"
+  (let [data (g/range 5)
+        table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")]
+    (g/write-delta! data table-path)
+    (let [delta-tbl (d/delta-table {:location table-path})]
+      (fact "Delete rows by condition"
+        (d/delete delta-tbl (g/>= (g/col :id) (g/lit 3)))
+        (stable-collect (d/to-df delta-tbl)) => (stable-collect (g/range 3)))
+
+      ;; @todo Uncomment these tests once Delta has been upgraded to support Spark 3.1.x
+      ;; These tests pass against Spark 3.0.2
+      ;(fact "Update all rows"
+      ;  (d/update delta-tbl {:id (g/* (g/col :id) 2)})
+      ;  (stable-collect (d/to-df delta-tbl)) => [{:id 0} {:id 2} {:id 4}])
+      ;
+      ;(fact "Update rows by condition"
+      ;  (d/update delta-tbl
+      ;            (g/=== (g/col :id) (g/lit 0))
+      ;            {:id (g/lit 10)})
+      ;  (stable-collect (d/to-df delta-tbl)) => [{:id 2} {:id 4} {:id 10}])
+
+      (fact "Delete all rows"
+        (d/delete delta-tbl)
+        (stable-collect (d/to-df delta-tbl)) => [])
+
+      (fact "Atomic (transactional) appends"
+        (g/write-delta! (g/range 3) table-path {:mode "append"}))
+
+      (fact "Read version history"
+        (-> (d/history delta-tbl)
+            (g/order-by :version)
+            (g/collect-col :operation)) => ["WRITE" "DELETE" "DELETE" "WRITE"]) ;; Should be ["WRITE" "DELETE" "UPDATE" "UPDATE" "DELETE" "WRITE"]
+
+      (fact "Vacuuming files that are no longer active"
+        (g/with-settings
+          @tr/spark
+          {:spark.databricks.delta.retentionDurationCheck.enabled false}
+          (fn [_]
+            (d/vacuum delta-tbl 0.0)))
+
+        ;; Convert to normal parquet (requires vacuuming first)
+        ;; https://docs.delta.io/0.8.0/delta-utility.html#convert-a-delta-table-to-a-parquet-table
+        (-> (tr/join-paths table-path "_delta_log")
+            File.
+            tr/recursive-delete-dir)
+        (stable-collect (g/read-parquet! table-path)) => (stable-collect (g/range 3))))))
+
+;; @todo Uncomment these tests once Delta has been upgraded to support Spark 3.1.x
+;; These tests pass against Spark 3.0.2
+;(facts "On Delta merge"
+;  (let [data (g/records->dataset [{:id 0 :s "A" :b false}
+;                                  {:id 1 :s "B" :b false}
+;                                  {:id 2 :s "C" :b false}])]
+;    (fact "Delete when matched; insert when not matched"
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 1 :s "Z" :b true}
+;                      {:id 3 :s "Z" :b true}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition        (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-matched     [{::d/on-match :delete ::d/column-rule :all}]
+;                  ::d/when-not-matched {::d/on-not-match :insert ::d/column-rule :all}})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "A" :b false}
+;                                                 {:id 2 :s "C" :b false}
+;                                                 {:id 3 :s "Z" :b true}]
+;        (tr/recursive-delete-dir (File. table-path))))
+;    (fact "Update all when matched; insert when not matched"
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 1 :s "Z" :b true}
+;                      {:id 3 :s "Z" :b true}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition        (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-matched     [{::d/on-match :update ::d/column-rule :all}]
+;                  ::d/when-not-matched {::d/on-not-match :insert ::d/column-rule :all}})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "A" :b false}
+;                                                 {:id 1 :s "Z" :b true}
+;                                                 {:id 2 :s "C" :b false}
+;                                                 {:id 3 :s "Z" :b true}]
+;        (tr/recursive-delete-dir (File. table-path))))
+;    (fact "Update on condition when matched; noop when not matched"
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (g/write-delta! data table-path {:mode "overwrite"})
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 1 :s "Z" :b true}
+;                      {:id 2 :s "Z" :b false}
+;                      {:id 3 :s "Z" :b true}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition    (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-matched [{::d/condition   (g/col :src.b)
+;                                     ::d/on-match    :update
+;                                     ::d/column-rule {:dest.id (g/* (g/col :dest.id) (g/lit 10))}}]})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "A" :b false}
+;                                                 {:id 2 :s "C" :b false}
+;                                                 {:id 10 :s "B" :b false}]))
+;    (fact "Noop when matched; insert on condition when not matched"
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (g/write-delta! data table-path {:mode "overwrite"})
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 1 :s "Z" :b true}
+;                      {:id 3 :s "Z" :b false}
+;                      {:id 4 :s "Z" :b true}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition        (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-not-matched {::d/condition    (g/col :src.b)
+;                                        ::d/on-not-match :insert
+;                                        ::d/column-rule  :all}})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "A" :b false}
+;                                                 {:id 1 :s "B" :b false}
+;                                                 {:id 2 :s "C" :b false}
+;                                                 {:id 4 :s "Z" :b true}]))
+;    (fact "Update on condition when matched; update all when matched; noop when not matched."
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (g/write-delta! data table-path {:mode "overwrite"})
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 0 :s "Z" :b false}
+;                      {:id 1 :s "Z" :b true}
+;                      {:id 2 :s "Z" :b false}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition        (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-matched     [{::d/condition   (g/col :src.b)
+;                                         ::d/on-match    :update
+;                                         ::d/column-rule {:dest.id (g/* (g/col :dest.id) (g/lit 10))}}
+;                                        {::d/on-match :update
+;                                         ::d/column-rule :all}]})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "Z" :b false}
+;                                                 {:id 2 :s "Z" :b false}
+;                                                 {:id 10 :s "B" :b false}]))
+;    (fact "Noop when matched; insert with column rule when not matched"
+;      (let [table-path (tr/join-paths (.toString (tr/create-temp-dir!)) "delta_test")
+;            _ (g/write-delta! data table-path)
+;            delta-tbl (d/delta-table {:location table-path})]
+;        (g/write-delta! data table-path {:mode "overwrite"})
+;        (d/merge (d/as delta-tbl "dest")
+;                 (-> [{:id 3 :s "Z" :b false}
+;                      {:id 4 :s "Z" :b true}]
+;                     g/records->dataset
+;                     (g/as "src"))
+;                 {::d/condition        (g/=== (g/col :dest.id) (g/col :src.id))
+;                  ::d/when-not-matched {::d/condition    (g/col :src.b)
+;                                        ::d/on-not-match :insert
+;                                        ::d/column-rule  {:dest.id (g/* (g/col :src.id) (g/lit 10))}}})
+;        (stable-collect (d/to-df delta-tbl)) => [{:id 0 :s "A" :b false}
+;                                                 {:id 1 :s "B" :b false}
+;                                                 {:id 2 :s "C" :b false}
+;                                                 {:id 40 :s nil :b nil}]))))

--- a/test/zero_one/geni/test_resources.clj
+++ b/test/zero_one/geni/test_resources.clj
@@ -41,6 +41,10 @@
                :timestamp (long (Integer/parseInt (nth row 3)))}))
        (g/records->dataset @spark)))
 
+(defn join-paths ^String
+  [root & path-parts]
+  (.toString (Paths/get root (into-array String path-parts))))
+
 (def -tmp-dir-attr
   (into-array FileAttribute '()))
 
@@ -66,11 +70,11 @@
       (recursive-delete-dir wh-dir))))
 
 (def test-warehouses-root
-  (str (Paths/get (.getAbsolutePath (io/file "")) (into-array String ["spark-warehouses"]))))
+  (join-paths (System/getProperty "user.dir") "spark-warehouses"))
 
 (defn rand-wh-path
   []
-  (str "file:" (Paths/get test-warehouses-root (into-array String [(str (UUID/randomUUID))]))))
+  (str "file:" (join-paths test-warehouses-root (str (UUID/randomUUID)))))
 
 (defn reset-session!
   []


### PR DESCRIPTION
Adds support for [Delta Lake](https://delta.io/) storage format. This PR is best reviewed 1 commit at a time.

Currently, some core functionality of Delta is disabled due to a [known incompatibility between Spark 3.1 and Delta 0.7+](https://github.com/delta-io/delta/issues/594). Once these issues are addressed in the next Delta release, the commented out code in this PR should be uncommented. All commented out code has been tested on Spark 3.0.2 + Delta 0.8.

I chose to implement the Delta API as using `with-dynamic-import`, but I am not confident in this decision and would love feedback. My editor fails to recognize any symbol defined within `with-dynamic-import` which hinders navigation and refactoring. 

Some things I would like to do before calling this PR done:
- [ ] Add docstrings
- [ ] Get feedback on the data-oriented interface for merge strategies. [Corresponding Scala documentation here.](https://docs.delta.io/latest/api/scala/io/delta/tables/DeltaMergeBuilder.html)