### PR TITLE
Add fields of struct array support to dataframe creation functions

### DIFF
--- a/src/clojure/zero_one/geni/core/dataset_creation.clj
+++ b/src/clojure/zero_one/geni/core/dataset_creation.clj
@@ -50,9 +50,10 @@
   "Creates an ArrayType by specifying the data type of elements `val-type` and
    whether the array contains null values `nullable`."
   [val-type nullable]
-  (DataTypes/createArrayType
-   (data-type->spark-type val-type)
-   nullable))
+  (let [spark-type (if (instance? DataType val-type)
+                     val-type
+                     (data-type->spark-type val-type))]
+    (DataTypes/createArrayType spark-type nullable)))
 
 (defn map-type
   "Creates a MapType by specifying the data type of keys `key-type`, the data type


### PR DESCRIPTION
See #333 

- Extend `array-type` to support any Spark SQL `DataType`, in the same fashion we are already doing in `struct-field`.
- Improve `create-dataframe` tests, adding tests for struct fields and struct array fields