### PR TITLE
Fix bug where g/->dataset doesn't work for more than 8 columns

### DIFF
--- a/src/clojure/zero_one/geni/core/dataset_creation.clj
+++ b/src/clojure/zero_one/geni/core/dataset_creation.clj
@@ -164,6 +164,8 @@
    For list of maps, it returns a list of one map with first non-nil value for each nested key.
      
      Examples:
+     []                                          => []
+     [nil nil]                                   => []
      [1 2 3]                                     => [1]
      [nil [1 2]]                                 => [[1]]
      [{:a 1} {:a 3 :b true}]                     => [{:a 1 :b true}]
@@ -186,6 +188,10 @@
    The sample non-nil value can be generated using first-non-nil function above.
    
      Examples:
+     [] | []
+      => []
+     [nil nil] | []
+      => [nil nil]
      [1 2 3] | [1]
       => [1 2 3]
      [nil [1 2]] | [[1]]
@@ -235,7 +241,7 @@
      (let [col-names  (map name col-names)
            transposed (transpose table)
            values     (map first-non-nil transposed)
-           table      (transpose (map (partial apply fill-missing-nested-keys) (zipmap transposed values)))
+           table      (transpose (map (partial apply fill-missing-nested-keys) (map vector transposed values)))
            rows       (interop/->java-list (map interop/->spark-row (transform-maps table)))
            schema     (infer-schema col-names (map first values))]
        (.createDataFrame spark rows schema)))))

--- a/test/zero_one/geni/dataset_creation_test.clj
+++ b/test/zero_one/geni/dataset_creation_test.clj
@@ -227,7 +227,25 @@
       (instance? Dataset dataset) => true
       (g/collect-vals dataset) => [[0 [[{:z 1 :h nil :g nil} {:z 2 :h nil :g nil}]
                                        [{:z nil :h true :g nil}]]]
-                                   [1 [[{:z nil :h nil :g 3.0}]]]])))
+                                   [1 [[{:z nil :h nil :g 3.0}]]]]))
+  (fact "should work for several number of columns"
+    (let [dataset (g/records->dataset
+                   @tr/spark
+                   [{:a 1  :b 2  :c 3  :d 4  :e 5  :f 6  :g 7  :h 8  :i 9}
+                    {:a 10 :b 11 :c 12 :d 13 :e 14 :f 15 :g 16 :h 17 :i 18}])]
+      (instance? Dataset dataset) => true
+      (g/collect dataset) => [{:a 1  :b 2  :c 3  :d 4  :e 5  :f 6  :g 7  :h 8  :i 9}
+                              {:a 10 :b 11 :c 12 :d 13 :e 14 :f 15 :g 16 :h 17 :i 18}]))
+  (fact "should work for nil and empty values"
+    (let [dataset (g/records->dataset
+                   @tr/spark
+                   [{:i nil :s []        :b []}
+                    {:i nil :s [nil nil] :b []}
+                    {:i nil :s nil       :b []}])]
+      (instance? Dataset dataset) => true
+      (g/collect-vals dataset) => [[nil []        []]
+                                   [nil [nil nil] []]
+                                   [nil nil       []]])))
 
 (facts "On table->dataset"
   (fact "should create the right dataset"


### PR DESCRIPTION
<!-- Credit to https://github.com/junegunn/fzf for the base template! -->

<!-- Check with [x] -->

- [x] I have read through the quick start and installation sections of the [README](../README.md).

## Info

<!-- Fill in the ... -->

| Info             | Value |
| ---              | ---   |
| Geni Version     | 0.0.39  |

## Problem / Steps to reproduce

<!-- Please explain your problem and ideally a minimal setup to reproduce -->

<!-- If possible, please consider replicating the issue inside a Docker container. -->

<!-- For instance, use `docker run --rm -it clojure:openjdk-11-lein-2.9.1 /bin/bash` + a list of bash commands -->

Many apologies, I introduced a bug in https://github.com/zero-one-group/geni/pull/336 where `g/->dataset` loses order of the values when there are more than 8 columns:
```clj
(-> (g/records->dataset
     @tr/spark
     [{:a 1  :b 2  :c 3  :d 4  :e 5  :f 6  :g 7  :h 8  :i 9}
      {:a 10 :b 11 :c 12 :d 13 :e 14 :f 15 :g 16 :h 17 :i 18}])
    g/collect)
```
leads to
```clj
;({:e 9, :g 3, :c 1, :h 5, :b 2, :d 6, :f 4, :i 7, :a 8}
; {:e 18, :g 12, :c 10, :h 14, :b 11, :d 15, :f 13, :i 16, :a 17})
```
## Expected Result

`g/collect` should return the same output as the one we provided to `g/->dataset`

## Proposed Solution

Dont use `zipmap` in https://github.com/zero-one-group/geni/blob/b7323bdb399611323b66c924dcb1098f36012a2a/src/clojure/zero_one/geni/core/dataset_creation.clj#L238

### Background

- Clojure switches from PersistentArrayMap to PersistentHashMap for maps when there are more than 8 entries as seen here https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/PersistentArrayMap.java#L33
- Using zipmap causes us to lose the order of table values and it doesn't match `col-names`  anymore