### PR TITLE
Exclude `abs` in `src/clojure/zero_one/geni/core/functions.clj`

### DIFF
--- a/src/clojure/zero_one/geni/core/functions.clj
+++ b/src/clojure/zero_one/geni/core/functions.clj
@@ -1,5 +1,6 @@
 (ns zero-one.geni.core.functions
-  (:refer-clojure :exclude [concat
+  (:refer-clojure :exclude [abs
+                            concat
                             flatten
                             hash
                             map


### PR DESCRIPTION
- Solves the second warning in #348 