### PR TITLE
Fix `already refers` warnings in Clojure 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Geni (*/gɜni/* or "gurney" without the r) is a [Clojure](https://clojure.org/) dataframe library that runs on [Apache Spark](https://spark.apache.org/). The name means "fire" in Javanese.
 
-[![CI](https://github.com/zero-one-group/geni/workflows/Continuous%20Integration/badge.svg?branch=develop)](https://github.com/zero-one-group/geni/actions)
+[![CI](https://github.com/zero-one-group/geni/actions/workflows/continuous-integration.yml/badge.svg?branch=develop)](https://github.com/zero-one-group/geni/actions)
 [![Code Coverage](https://codecov.io/gh/zero-one-group/geni/branch/develop/graph/badge.svg)](https://codecov.io/gh/zero-one-group/geni)
 [![Clojars Project](https://img.shields.io/clojars/v/zero.one/geni.svg)](http://clojars.org/zero.one/geni)
 [![License](https://img.shields.io/github/license/zero-one-group/geni.svg)](LICENSE)

--- a/docker/project.clj
+++ b/docker/project.clj
@@ -38,10 +38,11 @@
   :license {:name "Apache License"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[camel-snake-kebab "0.4.2"]
+                 [com.taoensso/nippy "3.3.0"]
                  [expound "0.8.9"]
                  [metosin/jsonista "0.3.3"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.taoensso/nippy "3.1.1"]
+                 [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [nrepl "0.8.3"]
                  [org.clojure/clojure "1.10.3"]
                  [org.clojure/java.data "1.0.86"]
@@ -54,8 +55,8 @@
    :uberjar {:aot :all :dependencies ~spark-deps}
    :dev {:dependencies [[criterium "0.4.6"]
                         [enlive "1.1.6"]
-                        [midje "1.10.3"]
-                        [techascent/tech.ml.dataset "5.21"
+                        [midje "1.10.9"]
+                        [techascent/tech.ml.dataset "6.024"
                          :exclusions [ch.qos.logback/logback-classic]]]
          :plugins [[lein-ancient "0.7.0"]
                    [lein-cloverage "1.2.2"]

--- a/docker/project.clj
+++ b/docker/project.clj
@@ -56,7 +56,7 @@
    :dev {:dependencies [[criterium "0.4.6"]
                         [enlive "1.1.6"]
                         [midje "1.10.9"]
-                        [techascent/tech.ml.dataset "6.024"
+                        [techascent/tech.ml.dataset "6.101"
                          :exclusions [ch.qos.logback/logback-classic]]]
          :plugins [[lein-ancient "0.7.0"]
                    [lein-cloverage "1.2.2"]

--- a/project.clj
+++ b/project.clj
@@ -54,7 +54,7 @@
    :uberjar {:aot :all :dependencies ~spark-deps}
    :dev {:dependencies [[criterium "0.4.6"]
                         [enlive "1.1.6"]
-                        [midje "1.10.3"]
+                        [midje "1.10.9"]
                         [techascent/tech.ml.dataset "5.21"
                          :exclusions [ch.qos.logback/logback-classic]]]
          :plugins [[lein-ancient "0.7.0"]

--- a/project.clj
+++ b/project.clj
@@ -56,7 +56,7 @@
    :dev {:dependencies [[criterium "0.4.6"]
                         [enlive "1.1.6"]
                         [midje "1.10.9"]
-                        [techascent/tech.ml.dataset "6.024"
+                        [techascent/tech.ml.dataset "6.101"
                          :exclusions [ch.qos.logback/logback-classic]]]
          :plugins [[lein-ancient "0.7.0"]
                    [lein-cloverage "1.2.2"]

--- a/project.clj
+++ b/project.clj
@@ -38,10 +38,11 @@
   :license {:name "Apache License"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[camel-snake-kebab "0.4.2"]
+                 [com.taoensso/nippy "3.3.0"]
                  [expound "0.8.9"]
                  [metosin/jsonista "0.3.3"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.taoensso/nippy "3.3.0"]
+                 [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [nrepl "0.8.3"]
                  [org.clojure/clojure "1.10.3"]
                  [org.clojure/java.data "1.0.86"]

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
                  [expound "0.8.9"]
                  [metosin/jsonista "0.3.3"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [com.taoensso/nippy "3.1.1"]
+                 [com.taoensso/nippy "3.3.0"]
                  [nrepl "0.8.3"]
                  [org.clojure/clojure "1.10.3"]
                  [org.clojure/java.data "1.0.86"]

--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,7 @@
    :dev {:dependencies [[criterium "0.4.6"]
                         [enlive "1.1.6"]
                         [midje "1.10.9"]
-                        [techascent/tech.ml.dataset "5.21"
+                        [techascent/tech.ml.dataset "6.024"
                          :exclusions [ch.qos.logback/logback-classic]]]
          :plugins [[lein-ancient "0.7.0"]
                    [lein-cloverage "1.2.2"]


### PR DESCRIPTION
- Closes #348
  - Upgrade `nippy` from `3.1.1` to `3.3.0`
  - Upgrade `midje` from `1.10.3` to `1.10.9`
  - Upgrade `tech.ml.dataset` from `5.21` to `6.101`
  - Specify `parsley` version as `0.9.3`